### PR TITLE
feat : 이메일 인증을 통한 회원 가입 구현

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,7 +42,7 @@ jobs:
             
     ## create application-dev.yml
     - name: make application-dev.yml
-      if: contains(github.ref, 'develop')
+      if: contains(github.ref, 'main') == false
       run: |
         cd ./src/main/resources
         touch ./application-dev.yml

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'mysql:mysql-connector-java:8.0.28'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/seungah/todayclothes/common/exception/ErrorCode.java
+++ b/src/main/java/com/seungah/todayclothes/common/exception/ErrorCode.java
@@ -10,9 +10,15 @@ public enum ErrorCode {
 
 	/* 400 */
 	METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "METHOD_ARGUMENT_NOT_VALID", "입력값 유효성 검사에 실패하였습니다."),
+	ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "ALREADY_EXISTS_EMAIL", "이미 가입된 이메일 주소입니다."),
+
+	/* 404 */
+	NOT_FOUND_AUTH_KEY(HttpStatus.NOT_FOUND, "NOT_FOUND_AUTH_KEY", "해당 인증 코드는 존재하지 않습니다."),
 
 	/* 500 */
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "예상치 못한 서버 에러가 발생했습니다.");
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "예상치 못한 서버 에러가 발생했습니다."),
+	FAILED_SEND_MAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_SEND_MAIL", "메일 전송에 실패했습니다.")
+	;
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/seungah/todayclothes/configuration/RedisConfiguration.java
+++ b/src/main/java/com/seungah/todayclothes/configuration/RedisConfiguration.java
@@ -1,0 +1,36 @@
+package com.seungah.todayclothes.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfiguration {
+
+	@Value("${spring.redis.host}")
+	private String redisHost;
+
+	@Value("${spring.redis.port}")
+	private int redisPort;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(redisHost, redisPort);
+	}
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate() {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		return redisTemplate;
+	}
+
+}

--- a/src/main/java/com/seungah/todayclothes/controller/AuthController.java
+++ b/src/main/java/com/seungah/todayclothes/controller/AuthController.java
@@ -1,0 +1,45 @@
+package com.seungah.todayclothes.controller;
+
+import com.seungah.todayclothes.dto.request.CheckAuthKeyRequest;
+import com.seungah.todayclothes.dto.request.SendAuthKeyRequest;
+import com.seungah.todayclothes.dto.request.SignUpRequest;
+import com.seungah.todayclothes.dto.response.CheckAuthKeyResponse;
+import com.seungah.todayclothes.service.AuthService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+	private final AuthService authService;
+
+	@PostMapping("/sign-up")
+	public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
+		authService.register(
+			request.getEmail(), request.getPassword(), request.getName()
+		);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/email/auth-key")
+	public ResponseEntity<Void> sendAuthKeyByMail(@RequestBody @Valid SendAuthKeyRequest request) {
+		authService.sendAuthKeyByMail(request.getEmail());
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/email/auth-key/check")
+	public ResponseEntity<CheckAuthKeyResponse> checkAuthKey(@RequestBody @Valid CheckAuthKeyRequest request) {
+		return ResponseEntity.ok(
+			authService.checkAuthKey(request.getEmail(), request.getAuthKey())
+		);
+	}
+
+}

--- a/src/main/java/com/seungah/todayclothes/dto/request/CheckAuthKeyRequest.java
+++ b/src/main/java/com/seungah/todayclothes/dto/request/CheckAuthKeyRequest.java
@@ -1,0 +1,15 @@
+package com.seungah.todayclothes.dto.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class CheckAuthKeyRequest {
+
+	@Email(message = "이메일 형식이 올바르지 않습니다.")
+	private String email;
+
+	@NotBlank(message = "인증 코드를 입력해 주세요.")
+	private String authKey;
+}

--- a/src/main/java/com/seungah/todayclothes/dto/request/SendAuthKeyRequest.java
+++ b/src/main/java/com/seungah/todayclothes/dto/request/SendAuthKeyRequest.java
@@ -1,0 +1,12 @@
+package com.seungah.todayclothes.dto.request;
+
+import javax.validation.constraints.Email;
+import lombok.Getter;
+
+@Getter
+public class SendAuthKeyRequest {
+
+	@Email(message = "이메일 형식이 올바르지 않습니다.")
+	private String email;
+
+}

--- a/src/main/java/com/seungah/todayclothes/dto/request/SignInRequest.java
+++ b/src/main/java/com/seungah/todayclothes/dto/request/SignInRequest.java
@@ -1,0 +1,16 @@
+package com.seungah.todayclothes.dto.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SignInRequest {
+
+	@Email(message = "이메일 형식이 올바르지 않습니다.")
+	private String email;
+
+	@NotBlank(message = "비밀번호 입력은 필수입니다.")
+	private String password;
+
+}

--- a/src/main/java/com/seungah/todayclothes/dto/request/SignUpRequest.java
+++ b/src/main/java/com/seungah/todayclothes/dto/request/SignUpRequest.java
@@ -1,0 +1,23 @@
+package com.seungah.todayclothes.dto.request;
+
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SignUpRequest {
+
+	@Email(message = "이메일 형식이 올바르지 않습니다.")
+	private String email;
+
+	@NotBlank(message = "비밀번호 입력은 필수입니다.")
+	private String password;
+
+	@NotBlank(message = "이름을 입력해 주세요")
+	private String name;
+
+	@AssertTrue(message = "이메일 인증을 해주세요.")
+	private boolean emailAuthResult;
+
+}

--- a/src/main/java/com/seungah/todayclothes/dto/response/CheckAuthKeyResponse.java
+++ b/src/main/java/com/seungah/todayclothes/dto/response/CheckAuthKeyResponse.java
@@ -1,0 +1,11 @@
+package com.seungah.todayclothes.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CheckAuthKeyResponse {
+	private boolean result;
+
+}

--- a/src/main/java/com/seungah/todayclothes/repository/MemberRepository.java
+++ b/src/main/java/com/seungah/todayclothes/repository/MemberRepository.java
@@ -8,4 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+	boolean existsByEmail(String email);
+
+	Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/seungah/todayclothes/service/AuthService.java
+++ b/src/main/java/com/seungah/todayclothes/service/AuthService.java
@@ -1,0 +1,84 @@
+package com.seungah.todayclothes.service;
+
+import static com.seungah.todayclothes.common.exception.ErrorCode.ALREADY_EXISTS_EMAIL;
+
+import com.seungah.todayclothes.common.exception.CustomException;
+import com.seungah.todayclothes.dto.response.CheckAuthKeyResponse;
+import com.seungah.todayclothes.entity.Member;
+import com.seungah.todayclothes.repository.MemberRepository;
+import com.seungah.todayclothes.type.SignUpType;
+import com.seungah.todayclothes.type.UserStatus;
+import com.seungah.todayclothes.util.AuthKeyRedisUtils;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+	private final MemberRepository memberRepository;
+	private final MailService mailService;
+	private final AuthKeyRedisUtils authKeyRedisUtils;
+
+	@Transactional
+	public void register(String email, String password, String name) {
+		if (memberRepository.existsByEmail(email)) {
+			throw new CustomException(ALREADY_EXISTS_EMAIL);
+		}
+
+		memberRepository.save(Member.builder()
+			.email(email)
+			.name(name)
+			.password(password) // TODO password 인코딩
+			.signUpType(SignUpType.EMAIL)
+			.userStatus(UserStatus.INACTIVE)
+			.build());
+	}
+
+	public void sendAuthKeyByMail(String email) {
+		if (memberRepository.existsByEmail(email)) {
+			throw new CustomException(ALREADY_EXISTS_EMAIL);
+		}
+
+		String authKey = issueAuthKey();
+
+		String subject = "[오늘 뭐 입지?] 회원 가입 인증 코드";
+		String text = "<h2>[오늘 뭐 입지?] 회원 가입 인증 코드</h2>\n"
+			+ "<p>안녕하세요.<br>귀하의 이메일 주소를 통해 "
+			+ "[오늘 뭐 입지?]에 대한 회원가입 인증 코드가 요청되었습니다.<br>"
+			+ "인증 코드는 다음과 같습니다.</p>"
+			+ "<h3>" + authKey + "</h3>";
+		mailService.sendMail(email, subject, text);
+
+		authKeyRedisUtils.put(email, authKey);
+
+	}
+
+	private String issueAuthKey() {
+		Random random = new Random();
+		StringBuilder authKey = new StringBuilder();
+
+		for (int i = 0; i < 5; i++) {
+			authKey.append(random.nextInt(9));
+		}
+
+		return authKey.toString();
+	}
+
+	public CheckAuthKeyResponse checkAuthKey(String email, String authKey) {
+
+		String authKeyInRedis = authKeyRedisUtils.get(email);
+		log.info(authKeyInRedis);
+		if (!authKey.equals(authKeyInRedis)) {
+			return new CheckAuthKeyResponse(false);
+		}
+
+		authKeyRedisUtils.delete(email);
+		return new CheckAuthKeyResponse(true);
+
+	}
+
+}

--- a/src/main/java/com/seungah/todayclothes/service/MailService.java
+++ b/src/main/java/com/seungah/todayclothes/service/MailService.java
@@ -1,0 +1,39 @@
+package com.seungah.todayclothes.service;
+
+import static com.seungah.todayclothes.common.exception.ErrorCode.FAILED_SEND_MAIL;
+
+import com.seungah.todayclothes.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class MailService {
+
+	private final JavaMailSender javaMailSender;
+
+	public void sendMail(String mail, String subject, String text) {
+		try {
+			MimeMessagePreparator message = mimeMessage -> {
+				MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, true,
+					"UTF-8");
+				mimeMessageHelper.setTo(mail);
+				mimeMessageHelper.setSubject(subject);
+				mimeMessageHelper.setText(text, true);
+			};
+
+			javaMailSender.send(message);
+		} catch (MailException e) {
+			log.error(e.getMessage());
+			throw new CustomException(FAILED_SEND_MAIL);
+		}
+
+	}
+
+}

--- a/src/main/java/com/seungah/todayclothes/util/AuthKeyRedisUtils.java
+++ b/src/main/java/com/seungah/todayclothes/util/AuthKeyRedisUtils.java
@@ -1,0 +1,36 @@
+package com.seungah.todayclothes.util;
+
+import com.seungah.todayclothes.common.exception.CustomException;
+import com.seungah.todayclothes.common.exception.ErrorCode;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class AuthKeyRedisUtils {
+
+	private static final int VALID_TIME = 10;
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void put(String email, String authKey) {
+		ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+		valueOperations.set(email, authKey, Duration.ofMinutes(VALID_TIME));
+	}
+
+	public String get(String email) {
+		ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+		String value = valueOperations.get(email);
+		if (value == null) {
+			throw new CustomException(ErrorCode.NOT_FOUND_AUTH_KEY);
+		}
+		return value;
+	}
+
+	public void delete(String email) {
+		redisTemplate.delete(email);
+	}
+
+}


### PR DESCRIPTION
## 📕 제목
- #1

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Redis 연동 및 회원 가입 인증 코드 유틸 생성
- [x] 회원 가입 구현
- [x] JavaMailSender를 이용한 인증 코드 메일 전송 서비스 구현
- [x] 메일로 발급 받은 회원 가입 인증 코드 입력 후, 일치하는지 확인

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- h2ju1004@gmail.com(내 계정)으로  gmail smtp 설정
- 10분으로 회원 가입 인증 코드 유효 시간 설정
- 로컬에선 docker로 redis 띄워서 작업하세요!!
- 회원 가입 절차 :
입력한 이메일 인증 코드 요청
-> 인증 코드 발급(redis에 키 저장)
->인증 코드 입력 & 일치하는지 확인(redis에 키 삭제)
-> 회원 가입 완료(mysql에 회원 저장)
- TO DO 회원 가입 시 password 인코딩 설정 (로그인 구현 시 할 예정!)
