### PR TITLE
feat : spring security + JWT를 사용한 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,11 +26,17 @@ dependencies {
     implementation 'mysql:mysql-connector-java:8.0.28'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'org.json:json:20220924'
+
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/seungah/todayclothes/common/exception/ErrorCode.java
+++ b/src/main/java/com/seungah/todayclothes/common/exception/ErrorCode.java
@@ -11,9 +11,19 @@ public enum ErrorCode {
 	/* 400 */
 	METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "METHOD_ARGUMENT_NOT_VALID", "입력값 유효성 검사에 실패하였습니다."),
 	ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "ALREADY_EXISTS_EMAIL", "이미 가입된 이메일 주소입니다."),
+	WRONG_EMAIL_OR_PASSWORD(HttpStatus.BAD_REQUEST, "WRONG_EMAIL_OR_PASSWORD", "잘못된 이메일/비밀번호입니다."),
+	INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+
+	/* 401 */
+	INVALID_AUTH(HttpStatus.UNAUTHORIZED, "INVALID_AUTH", "유효한 인증 정보가 아닙니다."),
+	EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_ACCESS_TOKEN", "Access Token이 만료되었습니다."),
+
+	/* 403 */
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "ACCESS_DENIED", "접근 권한이 없습니다."),
 
 	/* 404 */
 	NOT_FOUND_AUTH_KEY(HttpStatus.NOT_FOUND, "NOT_FOUND_AUTH_KEY", "해당 인증 코드는 존재하지 않습니다."),
+	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "NOT_FOUND_MEMBER", "해당 유저가 존재하지 않습니다."),
 
 	/* 500 */
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "예상치 못한 서버 에러가 발생했습니다."),

--- a/src/main/java/com/seungah/todayclothes/common/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/seungah/todayclothes/common/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.seungah.todayclothes.common.jwt;
+
+import static com.seungah.todayclothes.common.exception.ErrorCode.ACCESS_DENIED;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.json.JSONObject;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+		response.setContentType("application/json;charset=UTF-8");
+		response.setStatus(response.SC_FORBIDDEN);
+
+		JSONObject responseObject = new JSONObject();
+		responseObject.put("errorCode", ACCESS_DENIED.getCode());
+		responseObject.put("errorMessage", ACCESS_DENIED.getMessage());
+
+		response.getWriter().print(responseObject);
+
+	}
+}

--- a/src/main/java/com/seungah/todayclothes/common/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/seungah/todayclothes/common/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,47 @@
+package com.seungah.todayclothes.common.jwt;
+
+import static com.seungah.todayclothes.common.exception.ErrorCode.EXPIRED_ACCESS_TOKEN;
+import static com.seungah.todayclothes.common.exception.ErrorCode.INVALID_AUTH;
+import static com.seungah.todayclothes.common.exception.ErrorCode.INVALID_TOKEN;
+
+import com.seungah.todayclothes.common.exception.ErrorCode;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.json.JSONObject;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException, ServletException {
+
+		String exception = (String)request.getAttribute("exception");
+
+		if (exception.equals(EXPIRED_ACCESS_TOKEN.getCode())) {
+			setResponse(response, EXPIRED_ACCESS_TOKEN);
+		} else if (exception.equals(INVALID_TOKEN.getCode())) {
+			setResponse(response, INVALID_TOKEN);
+		} else {
+			setResponse(response, INVALID_AUTH);
+		}
+	}
+
+	private void setResponse(HttpServletResponse response, ErrorCode errorCode)
+		throws IOException {
+		response.setContentType("application/json;charset=UTF-8");
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+		JSONObject responseObject = new JSONObject();
+		responseObject.put("errorCode", errorCode.getCode());
+		responseObject.put("errorMessage", errorCode.getMessage());
+
+		response.getWriter().print(responseObject);
+
+	}
+}

--- a/src/main/java/com/seungah/todayclothes/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/seungah/todayclothes/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package com.seungah.todayclothes.common.jwt;
+
+import static com.seungah.todayclothes.common.exception.ErrorCode.EXPIRED_ACCESS_TOKEN;
+import static com.seungah.todayclothes.common.exception.ErrorCode.INVALID_TOKEN;
+import static com.seungah.todayclothes.common.jwt.JwtProvider.ACCESS_TOKEN_COOKIE_NAME;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+	private final JwtProvider jwtProvider;
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+		throws IOException, ServletException {
+
+		String token = resolveToken((HttpServletRequest) request);
+
+		try {
+			if (token != null) {
+				Authentication authentication = jwtProvider.getAuthentication(token);
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+		} catch (ExpiredJwtException e) {
+			log.info("만료된 토큰입니다.");
+			request.setAttribute("exception", EXPIRED_ACCESS_TOKEN.getCode());
+		} catch (MalformedJwtException e) {
+			log.info("손상된 토큰입니다.");
+			request.setAttribute("exception", INVALID_TOKEN.getCode());
+		} catch (SignatureException e) {
+			log.info("시그니처 검증에 실패한 토큰입니다.");
+			request.setAttribute("exception", INVALID_TOKEN.getCode());
+		} catch (UnsupportedJwtException e) {
+			log.info("지원되지 않는 형식이나 구성의 토큰입니다.");
+			request.setAttribute("exception", INVALID_TOKEN.getCode());
+		} catch (IllegalArgumentException e) {
+			log.info("유효하지 않은 토큰입니다.");
+			request.setAttribute("exception", INVALID_TOKEN.name());
+		}
+
+		chain.doFilter(request, response);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		String cookies = request.getHeader(HttpHeaders.COOKIE);
+		if(cookies == null) {
+			return null;
+		}
+
+		return cookies.split("; ")[0]
+			.replace(ACCESS_TOKEN_COOKIE_NAME + "=", "");
+	}
+}

--- a/src/main/java/com/seungah/todayclothes/common/jwt/JwtProvider.java
+++ b/src/main/java/com/seungah/todayclothes/common/jwt/JwtProvider.java
@@ -1,0 +1,91 @@
+package com.seungah.todayclothes.common.jwt;
+
+import com.seungah.todayclothes.dto.TokenDto;
+import com.seungah.todayclothes.util.TokenRedisUtils;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.server.Cookie.SameSite;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+	public static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+	public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+	private static final int CREATE_AGE = 7 * 24 * 60 * 60;
+	private final long ACCESS_TOKEN_EXPIRATION_TIME = 30 * 60 * 1000L; // 30분
+	private final long REFRESH_TOKEN_EXPIRATION_TIME = 14 * 24 * 60 * 60 * 1000L; // 2주
+
+	private final UserDetailsService userDetailsService;
+	private final TokenRedisUtils tokenRedisUtils;
+	private final Key secretKey;
+
+	public JwtProvider(
+		UserDetailsService userDetailsService,
+		@Value("${jwt.secret}") String secretKey,
+		TokenRedisUtils tokenRedisUtils
+	) {
+		this.userDetailsService = userDetailsService;
+		this.tokenRedisUtils = tokenRedisUtils;
+
+		byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+		this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+	}
+
+	public TokenDto issueToken(Long userId) {
+		Date now = new Date();
+		Date accessTokenExpiredDate = new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION_TIME);
+		Date refreshTokenExpiredDate = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME);
+		String accessToken = createToken(userId, now, accessTokenExpiredDate);
+		String refreshToken = createToken(userId, now, refreshTokenExpiredDate);
+
+		tokenRedisUtils.put(userId, refreshToken, refreshTokenExpiredDate);
+
+		return TokenDto.builder()
+			.accessTokenCookie(addCookie(accessToken, ACCESS_TOKEN_COOKIE_NAME))
+			.refreshTokenCookie(addCookie(refreshToken, REFRESH_TOKEN_COOKIE_NAME))
+			.build();
+	}
+
+	private String createToken(Long userId, Date now, Date expiredDate) {
+		return Jwts.builder()
+			.setSubject(String.valueOf(userId))
+			.setIssuedAt(now)
+			.setExpiration(expiredDate)
+			.signWith(secretKey, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	private ResponseCookie addCookie(String token, String name) {
+		return ResponseCookie.from(name, token)
+			.httpOnly(true)
+			.path("/")
+			.maxAge(CREATE_AGE)
+			.secure(true)
+			.sameSite(SameSite.NONE.attributeValue())
+			.build();
+	}
+
+	public Authentication getAuthentication(String accessToken) {
+		String userId = this.getUserId(accessToken);
+		UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
+
+		return new UsernamePasswordAuthenticationToken(Long.parseLong(userId), "", userDetails.getAuthorities());
+	}
+
+	public String getUserId(String accessToken) {
+		return Jwts.parserBuilder().setSigningKey(secretKey).build()
+			.parseClaimsJws(accessToken).getBody().getSubject();
+	}
+
+}

--- a/src/main/java/com/seungah/todayclothes/configuration/PasswordEncoderConfiguration.java
+++ b/src/main/java/com/seungah/todayclothes/configuration/PasswordEncoderConfiguration.java
@@ -1,0 +1,16 @@
+package com.seungah.todayclothes.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfiguration {
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+	}
+
+}

--- a/src/main/java/com/seungah/todayclothes/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/seungah/todayclothes/configuration/SecurityConfiguration.java
@@ -1,0 +1,62 @@
+package com.seungah.todayclothes.configuration;
+
+import static com.seungah.todayclothes.type.UserStatus.ACTIVE;
+import static com.seungah.todayclothes.type.UserStatus.INACTIVE;
+
+import com.seungah.todayclothes.common.jwt.JwtAccessDeniedHandler;
+import com.seungah.todayclothes.common.jwt.JwtAuthenticationEntryPoint;
+import com.seungah.todayclothes.common.jwt.JwtAuthenticationFilter;
+import com.seungah.todayclothes.common.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration {
+
+	private final JwtProvider jwtProvider;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+		http
+			.httpBasic().disable()
+			.csrf().disable()
+			.sessionManagement()
+			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+			.and()
+			.exceptionHandling()
+			.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+			.accessDeniedHandler(jwtAccessDeniedHandler)
+
+			.and()
+			.addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
+				UsernamePasswordAuthenticationFilter.class)
+
+			.authorizeRequests()
+			.antMatchers("/",
+				"/api/auth/sign-up",
+				"/api/auth/email/auth-key",
+				"/api/auth/email/auth-key/check",
+				"/api/auth/sign-in").permitAll()
+
+			.and()
+			.authorizeRequests()
+			// TODO mypage 등록, 수정
+			.antMatchers("/api/inactive").hasAnyRole(ACTIVE.name(), INACTIVE.name())
+			.antMatchers("/api/**").hasRole(ACTIVE.name());
+
+		return http.build();
+	}
+
+}

--- a/src/main/java/com/seungah/todayclothes/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/seungah/todayclothes/configuration/SecurityConfiguration.java
@@ -7,6 +7,7 @@ import com.seungah.todayclothes.common.jwt.JwtAccessDeniedHandler;
 import com.seungah.todayclothes.common.jwt.JwtAuthenticationEntryPoint;
 import com.seungah.todayclothes.common.jwt.JwtAuthenticationFilter;
 import com.seungah.todayclothes.common.jwt.JwtProvider;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @RequiredArgsConstructor
 @Configuration
@@ -31,6 +35,9 @@ public class SecurityConfiguration {
 		http
 			.httpBasic().disable()
 			.csrf().disable()
+			.cors().configurationSource(corsConfigurationSource())
+
+			.and()
 			.sessionManagement()
 			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 
@@ -58,5 +65,18 @@ public class SecurityConfiguration {
 
 		return http.build();
 	}
+
+	@Bean
+	CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOriginPatterns(Arrays.asList("*"));
+		configuration.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE"));
+		configuration.setAllowedHeaders(Arrays.asList("*")); // TODO Header 설정
+		configuration.setAllowCredentials(true);
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+
 
 }

--- a/src/main/java/com/seungah/todayclothes/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/seungah/todayclothes/configuration/SecurityConfiguration.java
@@ -70,7 +70,7 @@ public class SecurityConfiguration {
 	CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
 		configuration.setAllowedOriginPatterns(Arrays.asList("*"));
-		configuration.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE"));
+		configuration.setAllowedMethods(Arrays.asList("OPTIONS", "HEAD", "GET", "POST", "PUT", "DELETE"));
 		configuration.setAllowedHeaders(Arrays.asList("*")); // TODO Header 설정
 		configuration.setAllowCredentials(true);
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/seungah/todayclothes/controller/AuthController.java
+++ b/src/main/java/com/seungah/todayclothes/controller/AuthController.java
@@ -1,12 +1,16 @@
 package com.seungah.todayclothes.controller;
 
+import com.seungah.todayclothes.dto.TokenDto;
 import com.seungah.todayclothes.dto.request.CheckAuthKeyRequest;
 import com.seungah.todayclothes.dto.request.SendAuthKeyRequest;
+import com.seungah.todayclothes.dto.request.SignInRequest;
 import com.seungah.todayclothes.dto.request.SignUpRequest;
 import com.seungah.todayclothes.dto.response.CheckAuthKeyResponse;
 import com.seungah.todayclothes.service.AuthService;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,9 +41,22 @@ public class AuthController {
 
 	@PostMapping("/email/auth-key/check")
 	public ResponseEntity<CheckAuthKeyResponse> checkAuthKey(@RequestBody @Valid CheckAuthKeyRequest request) {
+
 		return ResponseEntity.ok(
 			authService.checkAuthKey(request.getEmail(), request.getAuthKey())
 		);
+	}
+
+	@PostMapping("/sign-in")
+	public ResponseEntity<Void> signIn(@RequestBody @Valid SignInRequest request,
+		HttpServletResponse response) {
+
+		TokenDto dto = authService.signIn(request.getEmail(), request.getPassword());
+
+		response.addHeader(HttpHeaders.SET_COOKIE, dto.getAccessTokenCookie().toString());
+		response.addHeader(HttpHeaders.SET_COOKIE, dto.getRefreshTokenCookie().toString());
+
+		return ResponseEntity.ok().build();
 	}
 
 }

--- a/src/main/java/com/seungah/todayclothes/dto/TokenDto.java
+++ b/src/main/java/com/seungah/todayclothes/dto/TokenDto.java
@@ -1,0 +1,18 @@
+package com.seungah.todayclothes.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseCookie;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenDto {
+
+	private ResponseCookie accessTokenCookie;
+	private ResponseCookie refreshTokenCookie;
+
+}

--- a/src/main/java/com/seungah/todayclothes/service/SecurityUserDetailService.java
+++ b/src/main/java/com/seungah/todayclothes/service/SecurityUserDetailService.java
@@ -1,0 +1,48 @@
+package com.seungah.todayclothes.service;
+
+import static com.seungah.todayclothes.type.UserStatus.ACTIVE;
+import static com.seungah.todayclothes.type.UserStatus.INACTIVE;
+
+import com.seungah.todayclothes.common.exception.CustomException;
+import com.seungah.todayclothes.common.exception.ErrorCode;
+import com.seungah.todayclothes.entity.Member;
+import com.seungah.todayclothes.repository.MemberRepository;
+import com.seungah.todayclothes.type.UserStatus;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class SecurityUserDetailService implements UserDetailsService {
+
+	private final MemberRepository memberRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+		Member member = memberRepository.findById(Long.parseLong(userId))
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+
+		return new User(String.valueOf(member.getId()), member.getPassword(),
+			getAuthorities(member.getUserStatus()));
+
+	}
+
+	private Collection<? extends GrantedAuthority> getAuthorities(UserStatus status) {
+		if (status == UserStatus.ACTIVE) {
+			return Arrays.asList(new SimpleGrantedAuthority("ROLE_" + ACTIVE.name()));
+		} else if (status == UserStatus.INACTIVE) {
+			return Arrays.asList(new SimpleGrantedAuthority("ROLE_" + INACTIVE.name()));
+		} else {
+			return Collections.emptyList();
+		}
+	}
+}

--- a/src/main/java/com/seungah/todayclothes/util/TokenRedisUtils.java
+++ b/src/main/java/com/seungah/todayclothes/util/TokenRedisUtils.java
@@ -1,0 +1,28 @@
+package com.seungah.todayclothes.util;
+
+import java.time.Duration;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class TokenRedisUtils {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void put(Long userId, String refreshToken, Date expiredDate) {
+		Date now = new Date();
+		long expirationSeconds = (expiredDate.getTime() - now.getTime()) / 1000;
+
+		if (expirationSeconds > 0) {
+			ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+			valueOperations.set(String.valueOf(userId), refreshToken,
+				Duration.ofSeconds(expirationSeconds));
+
+		}
+	}
+
+}


### PR DESCRIPTION
## 📕 제목
- #3 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] JWT 토큰(access, refresh) 발급, 검증 구현
- [x] (토큰 발급 시) refresh token 레디스에 저장 구현 
- [x] 로그인 API 구현
- [x] 인증, 인가 exception handling 구현
- [x] UserStatus인 ACTIVE, INACTIVE로 role 부여하였고, 권한 별 path 설정
- [x] CORS 설정
- [x] 패스워드 인코더 설정 + 회원 가입 시 패스워드 인코딩 추가 

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- jwt.secert은 base64로 제가 알아서 설정했고, github actions secret yml 파일 수정 완료 (디코로 yml 파일 공유할게염)
- access, refresh token 만료 기간을 각각 30분, 2주로 설정했습니다.
- 로그인 API 흐름 :
이메일, 비번 입력 후 검증
-> 검증 성공 시 access, refresh 토큰 발급
-> redis에 refresh 토큰 저장 (memberId(key), refresh token(value))
-> set-cookie 응답 헤더로 access token, refresh token 리턴
- 권한을 UserRole을 따로 만들기 애매해서, 우선 UserStatus인 ACTIVE와 INACTIVE로 설정해놨는데요. 의견 받습니다.
-> 직업, 성별 등 사용자 정보를 안 받았을 때 유저를 비활성화해 놓기 위한 용도입니다
- CORS 설정이 첨이라서요? _**승렬이!!!!!**_ 자세히 봐주세요
