### PR TITLE
Feat: 회원의 정보 CRUD 구현

### DIFF
--- a/src/main/java/com/seungah/todayclothes/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/seungah/todayclothes/configuration/SecurityConfiguration.java
@@ -7,9 +7,7 @@ import com.seungah.todayclothes.common.jwt.JwtAccessDeniedHandler;
 import com.seungah.todayclothes.common.jwt.JwtAuthenticationEntryPoint;
 import com.seungah.todayclothes.common.jwt.JwtAuthenticationFilter;
 import com.seungah.todayclothes.common.jwt.JwtProvider;
-
 import java.util.Arrays;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -61,8 +59,7 @@ public class SecurityConfiguration {
                         "/api/oauth/kakao/callback", "/api/oauth/naver/callback").permitAll()
                 .and()
                 .authorizeRequests()
-                // TODO mypage 등록, 수정
-                .antMatchers("/api/inactive").hasAnyRole(ACTIVE.name(), INACTIVE.name())
+                .antMatchers("/api/members/**").hasAnyRole(ACTIVE.name(), INACTIVE.name())
                 .antMatchers("/api/**").hasRole(ACTIVE.name());
 
         return http.build();

--- a/src/main/java/com/seungah/todayclothes/controller/MemberController.java
+++ b/src/main/java/com/seungah/todayclothes/controller/MemberController.java
@@ -1,0 +1,46 @@
+package com.seungah.todayclothes.controller;
+
+import com.seungah.todayclothes.dto.request.UpdateGenderRequest;
+import com.seungah.todayclothes.dto.request.UpdateRegionRequest;
+import com.seungah.todayclothes.dto.response.GetProfileResponse;
+import com.seungah.todayclothes.service.MemberService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/members")
+public class MemberController {
+
+	private final MemberService memberService;
+	@GetMapping("/profile")
+	public ResponseEntity<GetProfileResponse> getProfile(@AuthenticationPrincipal Long userId) {
+
+		return ResponseEntity.ok(memberService.getProfile(userId));
+	}
+
+	@PutMapping("/gender")
+	public ResponseEntity<GetProfileResponse> updateGender(@Valid @RequestBody UpdateGenderRequest request,
+		@AuthenticationPrincipal Long userId) {
+
+		return ResponseEntity.ok(
+			memberService.updateGender(userId, request.getGender())
+		);
+	}
+
+	@PutMapping("/region")
+	public ResponseEntity<GetProfileResponse> updateRegion(@Valid @RequestBody UpdateRegionRequest request,
+		@AuthenticationPrincipal Long userId) {
+
+		return ResponseEntity.ok(
+			memberService.updateRegion(userId, request.getRegion())
+		);
+	}
+}

--- a/src/main/java/com/seungah/todayclothes/dto/request/UpdateGenderRequest.java
+++ b/src/main/java/com/seungah/todayclothes/dto/request/UpdateGenderRequest.java
@@ -1,0 +1,15 @@
+package com.seungah.todayclothes.dto.request;
+
+import com.seungah.todayclothes.type.Gender;
+import com.seungah.todayclothes.type.valid.EnumTypeValid;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class UpdateGenderRequest {
+
+	@EnumTypeValid(enumClass = Gender.class, message = "Invalid Gender")
+	@NotNull(message = "성별(MALE, FEMALE)를 선택하세요.")
+	private String gender;
+
+}

--- a/src/main/java/com/seungah/todayclothes/dto/request/UpdateRegionRequest.java
+++ b/src/main/java/com/seungah/todayclothes/dto/request/UpdateRegionRequest.java
@@ -1,0 +1,10 @@
+package com.seungah.todayclothes.dto.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class UpdateRegionRequest {
+	@NotNull(message = "지역을 입력해 주세요.")
+	private String region;
+}

--- a/src/main/java/com/seungah/todayclothes/dto/response/GetProfileResponse.java
+++ b/src/main/java/com/seungah/todayclothes/dto/response/GetProfileResponse.java
@@ -1,0 +1,38 @@
+package com.seungah.todayclothes.dto.response;
+
+import com.seungah.todayclothes.entity.Member;
+import com.seungah.todayclothes.type.Gender;
+import com.seungah.todayclothes.type.SignUpType;
+import com.seungah.todayclothes.type.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GetProfileResponse {
+	private Long memberId;
+	private String email;
+	private String name;
+	//private String password;
+	private Gender gender;
+	private String region;
+	private SignUpType signUpType;
+	private UserStatus userStatus;
+
+	public static GetProfileResponse of(Member member) {
+		return GetProfileResponse.builder()
+			.memberId(member.getId())
+			.name(member.getName())
+			.email(member.getEmail())
+			.gender(member.getGender())
+			.region(member.getRegion())
+			.signUpType(member.getSignUpType())
+			.userStatus(member.getUserStatus())
+			.build();
+	}
+
+}

--- a/src/main/java/com/seungah/todayclothes/entity/Member.java
+++ b/src/main/java/com/seungah/todayclothes/entity/Member.java
@@ -37,6 +37,7 @@ public class Member extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	private Gender gender;
+	private String region; // TODO 지역 엔티티로 변경하기
 
 	@Column(unique = true)
 	private String kakaoUuid;
@@ -55,6 +56,26 @@ public class Member extends BaseEntity {
 	public Member naverIdUpdate(String naverUserId) {
 		this.naverUserId = naverUserId;
 		return this;
+	}
+
+	public Member genderUpdate(String gender) {
+		this.gender = Gender.valueOf(gender);
+		if (this.userStatus == UserStatus.INACTIVE && this.isActive()) {
+			this.userStatus = UserStatus.ACTIVE;
+		}
+		return this;
+	}
+
+	public Member regionUpdate(String region) {
+		this.region = region;
+		if (this.userStatus == UserStatus.INACTIVE && this.isActive()) {
+			this.userStatus = UserStatus.ACTIVE;
+		}
+		return this;
+	}
+
+	public boolean isActive() {
+		return this.gender != null && this.region != null;
 	}
 
 }

--- a/src/main/java/com/seungah/todayclothes/service/MemberService.java
+++ b/src/main/java/com/seungah/todayclothes/service/MemberService.java
@@ -1,0 +1,42 @@
+package com.seungah.todayclothes.service;
+
+import static com.seungah.todayclothes.common.exception.ErrorCode.NOT_FOUND_MEMBER;
+
+import com.seungah.todayclothes.common.exception.CustomException;
+import com.seungah.todayclothes.dto.response.GetProfileResponse;
+import com.seungah.todayclothes.entity.Member;
+import com.seungah.todayclothes.repository.MemberRepository;
+import com.seungah.todayclothes.type.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	public GetProfileResponse getProfile(Long userId) {
+		Member member = memberRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
+
+		return GetProfileResponse.of(member);
+	}
+
+	@Transactional
+	public GetProfileResponse updateGender(Long userId, String gender) {
+		Member member = memberRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
+
+		return GetProfileResponse.of(member.genderUpdate(gender));
+	}
+
+	@Transactional
+	public GetProfileResponse updateRegion(Long userId, String region) {
+		Member member = memberRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
+
+		return GetProfileResponse.of(member.regionUpdate(region));
+	}
+}

--- a/src/main/java/com/seungah/todayclothes/type/valid/EnumTypeValid.java
+++ b/src/main/java/com/seungah/todayclothes/type/valid/EnumTypeValid.java
@@ -1,0 +1,23 @@
+package com.seungah.todayclothes.type.valid;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = EnumValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnumTypeValid {
+
+	String message() default "Invalid value. This is not permitted.";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+	Class<? extends java.lang.Enum<?>> enumClass();
+	boolean ignoreCase() default false;
+
+}

--- a/src/main/java/com/seungah/todayclothes/type/valid/EnumValidator.java
+++ b/src/main/java/com/seungah/todayclothes/type/valid/EnumValidator.java
@@ -1,0 +1,30 @@
+package com.seungah.todayclothes.type.valid;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<EnumTypeValid, String> {
+
+	private EnumTypeValid annotation;
+
+	@Override
+	public void initialize(EnumTypeValid constraintAnnotation) {
+		this.annotation = constraintAnnotation;
+	}
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		boolean result = false;
+		Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+		if (enumValues != null) {
+			for (Object enumValue : enumValues) {
+				if (value.equals(enumValue.toString())
+					|| (this.annotation.ignoreCase() && value.equalsIgnoreCase(enumValue.toString()))) {
+					result = true;
+					break;
+				}
+			}
+		}
+		return result;
+	}
+}


### PR DESCRIPTION
## 📕 제목
- #7

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 필요한 정보(성별, 지역) 받을 시, 활성화 회원으로 변경
- [x] 회원 정보 보기
- [x] 성별 혹은 지역 입력 및 수정(PUT) API - 각자 수정할 수 있게 만듦
- [x] 성별, 지역 모두 NULL이 아닐 시, 회원 ACTIVE으로 변경 (ai 서비스 사용 가능)

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- TODO는 region 테이블 구성입니다
- 이름이나 비밀번호 변경은 추후에 할 예정입니다
- crud라 해놓고 d는 없네여 ㅎㅎ