### PR TITLE
Feat: 회원의 정보 수정 및 비밀번호 찾기

### DIFF
--- a/src/main/java/com/seungah/todayclothes/common/exception/ErrorCode.java
+++ b/src/main/java/com/seungah/todayclothes/common/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 	/* 404 */
 	NOT_FOUND_AUTH_KEY(HttpStatus.NOT_FOUND, "NOT_FOUND_AUTH_KEY", "해당 인증 코드는 존재하지 않습니다."),
 	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "NOT_FOUND_MEMBER", "해당 유저가 존재하지 않습니다."),
+	NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "NOT_FOUND_EMAIL", "해당 이메일 주소가 존재하지 않습니다."),
 
 	/* 500 */
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "예상치 못한 서버 에러가 발생했습니다."),

--- a/src/main/java/com/seungah/todayclothes/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/seungah/todayclothes/configuration/SecurityConfiguration.java
@@ -52,11 +52,10 @@ public class SecurityConfiguration {
 
                 .authorizeRequests()
                 .antMatchers("/",
-                        "/api/auth/sign-up",
-                        "/api/auth/email/auth-key",
-                        "/api/auth/email/auth-key/check",
-                        "/api/auth/sign-in",
-                        "/api/oauth/kakao/callback", "/api/oauth/naver/callback").permitAll()
+                        "/api/auth/sign-up", "/api/auth/sign-in",
+                        "/api/auth/email/auth-key", "/api/auth/email/auth-key/check",
+                        "/api/oauth/kakao/callback", "/api/oauth/naver/callback",
+                        "/api/members/password/find").permitAll()
                 .and()
                 .authorizeRequests()
                 .antMatchers("/api/members/**").hasAnyRole(ACTIVE.name(), INACTIVE.name())
@@ -69,7 +68,7 @@ public class SecurityConfiguration {
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(Arrays.asList("*"));
-        configuration.setAllowedMethods(Arrays.asList("OPTIONS", "HEAD", "GET", "POST", "PUT", "DELETE"));
+        configuration.setAllowedMethods(Arrays.asList("OPTIONS", "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE"));
         configuration.setAllowedHeaders(Arrays.asList("*")); // TODO Header 설정
         configuration.setAllowCredentials(true);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/seungah/todayclothes/controller/MemberController.java
+++ b/src/main/java/com/seungah/todayclothes/controller/MemberController.java
@@ -1,8 +1,9 @@
 package com.seungah.todayclothes.controller;
 
+import com.seungah.todayclothes.dto.request.FindPasswordRequest;
+import com.seungah.todayclothes.dto.request.UpdatePasswordRequest;
 import com.seungah.todayclothes.dto.request.UpdateGenderRequest;
 import com.seungah.todayclothes.dto.request.UpdateNameRequest;
-import com.seungah.todayclothes.dto.request.UpdatePasswordRequest;
 import com.seungah.todayclothes.dto.request.UpdateRegionRequest;
 import com.seungah.todayclothes.dto.response.GetProfileResponse;
 import com.seungah.todayclothes.service.MemberService;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -64,5 +66,12 @@ public class MemberController {
 
 		return ResponseEntity.ok().build();
 	}
-	
+
+	@PostMapping("/password/find")
+	public ResponseEntity<Void> findPassword(@Valid @RequestBody FindPasswordRequest request) {
+
+		memberService.findPassword(request.getEmail());
+
+		return ResponseEntity.ok().build();
+	}
 }

--- a/src/main/java/com/seungah/todayclothes/controller/MemberController.java
+++ b/src/main/java/com/seungah/todayclothes/controller/MemberController.java
@@ -1,6 +1,8 @@
 package com.seungah.todayclothes.controller;
 
 import com.seungah.todayclothes.dto.request.UpdateGenderRequest;
+import com.seungah.todayclothes.dto.request.UpdateNameRequest;
+import com.seungah.todayclothes.dto.request.UpdatePasswordRequest;
 import com.seungah.todayclothes.dto.request.UpdateRegionRequest;
 import com.seungah.todayclothes.dto.response.GetProfileResponse;
 import com.seungah.todayclothes.service.MemberService;
@@ -9,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,4 +46,23 @@ public class MemberController {
 			memberService.updateRegion(userId, request.getRegion())
 		);
 	}
+
+	@PatchMapping("/name")
+	public ResponseEntity<Void> updateName(@Valid @RequestBody UpdateNameRequest request,
+		@AuthenticationPrincipal Long userId) {
+
+		memberService.updateName(userId, request.getName());
+
+		return ResponseEntity.ok().build();
+	}
+
+	@PatchMapping("/password")
+	public ResponseEntity<Void> updatePassword(@Valid @RequestBody UpdatePasswordRequest request,
+		@AuthenticationPrincipal Long userId) {
+
+		memberService.updatePassword(userId, request.getPassword());
+
+		return ResponseEntity.ok().build();
+	}
+	
 }

--- a/src/main/java/com/seungah/todayclothes/dto/request/FindPasswordRequest.java
+++ b/src/main/java/com/seungah/todayclothes/dto/request/FindPasswordRequest.java
@@ -1,0 +1,11 @@
+package com.seungah.todayclothes.dto.request;
+
+import javax.validation.constraints.Email;
+import lombok.Getter;
+
+@Getter
+public class FindPasswordRequest {
+
+	@Email(message = "이메일 형식이 올바르지 않습니다.")
+	private String email;
+}

--- a/src/main/java/com/seungah/todayclothes/dto/request/UpdateNameRequest.java
+++ b/src/main/java/com/seungah/todayclothes/dto/request/UpdateNameRequest.java
@@ -1,0 +1,12 @@
+package com.seungah.todayclothes.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UpdateNameRequest {
+
+	@NotBlank(message = "이름을 입력해 주세요.")
+	private String name;
+
+}

--- a/src/main/java/com/seungah/todayclothes/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/seungah/todayclothes/dto/request/UpdatePasswordRequest.java
@@ -1,0 +1,12 @@
+package com.seungah.todayclothes.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UpdatePasswordRequest {
+
+	// TODO 패스워드 규칙
+	@NotBlank(message = "패스워드를 입력하세요.")
+	private String password;
+}

--- a/src/main/java/com/seungah/todayclothes/entity/Member.java
+++ b/src/main/java/com/seungah/todayclothes/entity/Member.java
@@ -15,7 +15,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @Builder
 @NoArgsConstructor

--- a/src/main/java/com/seungah/todayclothes/service/AuthService.java
+++ b/src/main/java/com/seungah/todayclothes/service/AuthService.java
@@ -12,6 +12,7 @@ import com.seungah.todayclothes.repository.MemberRepository;
 import com.seungah.todayclothes.type.SignUpType;
 import com.seungah.todayclothes.type.UserStatus;
 import com.seungah.todayclothes.util.AuthKeyRedisUtils;
+import com.seungah.todayclothes.util.MailUtils;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +27,7 @@ public class AuthService {
 
 	private final JwtProvider jwtProvider;
 	private final MemberRepository memberRepository;
-	private final MailService mailService;
+	private final MailUtils mailUtils;
 	private final AuthKeyRedisUtils authKeyRedisUtils;
 	private final PasswordEncoder passwordEncoder;
 
@@ -59,7 +60,7 @@ public class AuthService {
 			+ "[오늘 뭐 입지?]에 대한 회원가입 인증 코드가 요청되었습니다.<br>"
 			+ "인증 코드는 다음과 같습니다.</p>"
 			+ "<h3>" + authKey + "</h3>";
-		mailService.sendMail(email, subject, text);
+		mailUtils.sendMail(email, subject, text);
 
 		authKeyRedisUtils.put(email, authKey);
 

--- a/src/main/java/com/seungah/todayclothes/service/MemberService.java
+++ b/src/main/java/com/seungah/todayclothes/service/MemberService.java
@@ -6,8 +6,8 @@ import com.seungah.todayclothes.common.exception.CustomException;
 import com.seungah.todayclothes.dto.response.GetProfileResponse;
 import com.seungah.todayclothes.entity.Member;
 import com.seungah.todayclothes.repository.MemberRepository;
-import com.seungah.todayclothes.type.Gender;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
 	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
 
 	public GetProfileResponse getProfile(Long userId) {
 		Member member = memberRepository.findById(userId)
@@ -39,4 +40,19 @@ public class MemberService {
 
 		return GetProfileResponse.of(member.regionUpdate(region));
 	}
+
+	@Transactional
+	public void updateName(Long userId, String name) {
+		Member member = memberRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
+		member.setName(name);
+	}
+
+	@Transactional
+	public void updatePassword(Long userId, String password) {
+		Member member = memberRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
+		member.setPassword(passwordEncoder.encode(password));
+	}
+
 }

--- a/src/main/java/com/seungah/todayclothes/service/MemberService.java
+++ b/src/main/java/com/seungah/todayclothes/service/MemberService.java
@@ -1,11 +1,14 @@
 package com.seungah.todayclothes.service;
 
+import static com.seungah.todayclothes.common.exception.ErrorCode.NOT_FOUND_EMAIL;
 import static com.seungah.todayclothes.common.exception.ErrorCode.NOT_FOUND_MEMBER;
 
 import com.seungah.todayclothes.common.exception.CustomException;
 import com.seungah.todayclothes.dto.response.GetProfileResponse;
 import com.seungah.todayclothes.entity.Member;
 import com.seungah.todayclothes.repository.MemberRepository;
+import com.seungah.todayclothes.util.MailUtils;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,7 +20,8 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
-
+	private final MailUtils mailUtils;
+	
 	public GetProfileResponse getProfile(Long userId) {
 		Member member = memberRepository.findById(userId)
 			.orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
@@ -55,4 +59,29 @@ public class MemberService {
 		member.setPassword(passwordEncoder.encode(password));
 	}
 
+	@Transactional
+	public void findPassword(String email) {
+		Member member = memberRepository.findByEmail(email)
+			.orElseThrow(() -> new CustomException(NOT_FOUND_EMAIL));
+
+		String newPassword = UUID.randomUUID().toString(); // 임시로 발급한 패스워드
+		String encodedPassword = passwordEncoder.encode(newPassword);
+
+		sendNewPasswordByMail(email, newPassword);
+		member.setPassword(encodedPassword);
+
+	}
+
+	private void sendNewPasswordByMail(String email, String newPassword) {
+
+		String subject = "[오늘 뭐 입지?] 회원 임시 비밀번호";
+		String text = "<h2>[오늘 뭐 입지?] 회원 임시 비밀번호</h2>\n"
+			+ "<p>안녕하세요.<br>귀하의 이메일 주소를 통해 "
+			+ "[오늘 뭐 입지?]의 회원 임시 비밀번호가 요청되었습니다.<br>"
+			+ "비밀번호는 다음과 같습니다.</p>"
+			+ "<h3>" + newPassword + "</h3>"
+			+ "<p>회원가입 시 등록한 정보를 수정하려면, [마이페이지]에서 변경하실 수 있습니다.</p>";
+		mailUtils.sendMail(email, subject, text);
+
+	}
 }

--- a/src/main/java/com/seungah/todayclothes/util/MailUtils.java
+++ b/src/main/java/com/seungah/todayclothes/util/MailUtils.java
@@ -1,4 +1,4 @@
-package com.seungah.todayclothes.service;
+package com.seungah.todayclothes.util;
 
 import static com.seungah.todayclothes.common.exception.ErrorCode.FAILED_SEND_MAIL;
 
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class MailService {
+public class MailUtils {
 
 	private final JavaMailSender javaMailSender;
 


### PR DESCRIPTION
## 📕 제목
- #9 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 비밀번호, 이름 수정 API
- [x] 비밀번호 찾기 -> 이메일로 임시 비밀번호 발급

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 소셜 로그인을 한 사람은 이메일이 없는 경우가 있는데,
비밀번호 찾기 요청 시, email이 없으면 모두 NOT_FOUND_EMAIL 404 에러를 던지도록 했습니다.
- MailService -> MailUtils로 변경했습니다.
