### PR TITLE
Feat: SMS 유틸 및 핸드폰 번호 인증 구현

### DIFF
--- a/src/main/java/com/seungah/todayclothes/common/exception/ErrorCode.java
+++ b/src/main/java/com/seungah/todayclothes/common/exception/ErrorCode.java
@@ -33,7 +33,7 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "예상치 못한 서버 에러가 발생했습니다."),
 	FAILED_SEND_MAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_SEND_MAIL", "메일 전송에 실패했습니다."),
 	FAILED_SEND_SMS(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_SEND_SMS", "SMS 전송에 실패했습니다."),
-	FAILED_CALL_OPENWEATHERMAP_API(HttpStatus.INTERNAL_SERVER_ERROR, "HttpStatus.INTERNAL_SERVER_ERROR", "OpenWeatherMap API 요청에 실패했습니다.")
+	FAILED_CALL_OPENWEATHERMAP_API(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_CALL_OPENWEATHERMAP_API", "OpenWeatherMap API 요청에 실패했습니다.")
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/seungah/todayclothes/common/exception/ErrorCode.java
+++ b/src/main/java/com/seungah/todayclothes/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 
 	/* 404 */
 	NOT_FOUND_AUTH_KEY(HttpStatus.NOT_FOUND, "NOT_FOUND_AUTH_KEY", "해당 인증 코드는 존재하지 않습니다."),
+	NOT_FOUND_AUTH_NUMBER(HttpStatus.NOT_FOUND, "NOT_FOUND_AUTH_NUMBER", "해당 인증 번호는 존재하지 않습니다."),
 	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "NOT_FOUND_MEMBER", "해당 유저가 존재하지 않습니다."),
 	NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "NOT_FOUND_EMAIL", "해당 이메일 주소가 존재하지 않습니다."),
 	NOT_FOUND_SCHEDULE(HttpStatus.NOT_FOUND, "NOT_FOUND_SCHEDULE", "스케쥴을 찾을 수 없습니다." ),

--- a/src/main/java/com/seungah/todayclothes/common/exception/ErrorCode.java
+++ b/src/main/java/com/seungah/todayclothes/common/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 	/* 500 */
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "예상치 못한 서버 에러가 발생했습니다."),
 	FAILED_SEND_MAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_SEND_MAIL", "메일 전송에 실패했습니다."),
+	FAILED_SEND_SMS(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_SEND_SMS", "SMS 전송에 실패했습니다."),
 	FAILED_CALL_OPENWEATHERMAP_API(HttpStatus.INTERNAL_SERVER_ERROR, "HttpStatus.INTERNAL_SERVER_ERROR", "OpenWeatherMap API 요청에 실패했습니다.")
 	;
 

--- a/src/main/java/com/seungah/todayclothes/controller/MemberController.java
+++ b/src/main/java/com/seungah/todayclothes/controller/MemberController.java
@@ -1,10 +1,13 @@
 package com.seungah.todayclothes.controller;
 
+import com.seungah.todayclothes.dto.request.CheckAuthNumberRequest;
 import com.seungah.todayclothes.dto.request.FindPasswordRequest;
-import com.seungah.todayclothes.dto.request.UpdatePasswordRequest;
+import com.seungah.todayclothes.dto.request.SendAuthNumberRequest;
 import com.seungah.todayclothes.dto.request.UpdateGenderRequest;
 import com.seungah.todayclothes.dto.request.UpdateNameRequest;
+import com.seungah.todayclothes.dto.request.UpdatePasswordRequest;
 import com.seungah.todayclothes.dto.request.UpdateRegionRequest;
+import com.seungah.todayclothes.dto.response.CheckAuthNumberResponse;
 import com.seungah.todayclothes.dto.response.GetProfileResponse;
 import com.seungah.todayclothes.service.MemberService;
 import javax.validation.Valid;
@@ -47,6 +50,26 @@ public class MemberController {
 		return ResponseEntity.ok(
 			memberService.updateRegion(userId, request.getRegion())
 		);
+	}
+
+	@PostMapping("/phone/auth-num")
+	public ResponseEntity<Void> sendAuthNumberBySms(@Valid @RequestBody SendAuthNumberRequest request,
+		@AuthenticationPrincipal Long userId) {
+
+		memberService.sendAuthNumberBySms(userId, request.getPhone());
+
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/phone/auth-num/check")
+	public ResponseEntity<CheckAuthNumberResponse> checkAuthNumberAndSavePhone(
+		@Valid @RequestBody CheckAuthNumberRequest request,
+		@AuthenticationPrincipal Long userId
+	) {
+
+		return ResponseEntity.ok(
+			memberService.checkAuthNumberAndSavePhone(
+				userId, request.getAuthNumber(), request.getPhone()));
 	}
 
 	@PatchMapping("/name")

--- a/src/main/java/com/seungah/todayclothes/dto/SmsDto.java
+++ b/src/main/java/com/seungah/todayclothes/dto/SmsDto.java
@@ -1,0 +1,48 @@
+package com.seungah.todayclothes.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SmsDto {
+	private String type;
+	private String contentType;
+	private String countryCode;
+	private String from;
+	private String content;
+	private List<Message> messages;
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	public static class Message {
+
+		private String to;
+		private String content;
+
+		public static Message from(String from, String content) {
+			return Message.builder()
+				.to(from)
+				.content("[오늘 뭐 입지?] " + content)
+				.build();
+		}
+	}
+
+	public static SmsDto from(String from, String phone, List<Message> messages) {
+		return SmsDto.builder()
+			.type("SMS")
+			.contentType("COMM")
+			.countryCode("82")
+			.from(phone)
+			.content("content") // TODO 여러개 보낼 메시지가 있는지 토의
+			.messages(messages)
+			.build();
+	}
+}

--- a/src/main/java/com/seungah/todayclothes/dto/request/CheckAuthNumberRequest.java
+++ b/src/main/java/com/seungah/todayclothes/dto/request/CheckAuthNumberRequest.java
@@ -1,0 +1,15 @@
+package com.seungah.todayclothes.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class CheckAuthNumberRequest {
+
+	@Pattern(regexp = "^(010)(\\d{3,4})(\\d{4})$", message = "010xxx(x)xxxx 형식에 맞게 입력하세요.")
+	private String phone;
+
+	@NotBlank(message = "인증 코드를 입력해 주세요.")
+	private String authNumber;
+}

--- a/src/main/java/com/seungah/todayclothes/dto/request/SendAuthNumberRequest.java
+++ b/src/main/java/com/seungah/todayclothes/dto/request/SendAuthNumberRequest.java
@@ -1,0 +1,11 @@
+package com.seungah.todayclothes.dto.request;
+
+import javax.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class SendAuthNumberRequest {
+	@Pattern(regexp = "^(010)(\\d{3,4})(\\d{4})$", message = "010xxx(x)xxxx 형식에 맞게 입력하세요.")
+	private String phone;
+
+}

--- a/src/main/java/com/seungah/todayclothes/dto/response/CheckAuthNumberResponse.java
+++ b/src/main/java/com/seungah/todayclothes/dto/response/CheckAuthNumberResponse.java
@@ -1,0 +1,11 @@
+package com.seungah.todayclothes.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CheckAuthNumberResponse {
+	private boolean result;
+
+}

--- a/src/main/java/com/seungah/todayclothes/dto/response/GetProfileResponse.java
+++ b/src/main/java/com/seungah/todayclothes/dto/response/GetProfileResponse.java
@@ -20,6 +20,7 @@ public class GetProfileResponse {
 	//private String password;
 	private Gender gender;
 	private String region;
+	private String phone;
 	private SignUpType signUpType;
 	private UserStatus userStatus;
 
@@ -30,6 +31,7 @@ public class GetProfileResponse {
 			.email(member.getEmail())
 			.gender(member.getGender())
 			.region(member.getRegion())
+			.phone(member.getPhone())
 			.signUpType(member.getSignUpType())
 			.userStatus(member.getUserStatus())
 			.build();

--- a/src/main/java/com/seungah/todayclothes/entity/Member.java
+++ b/src/main/java/com/seungah/todayclothes/entity/Member.java
@@ -42,7 +42,7 @@ public class Member extends BaseEntity {
 	private String region; // TODO 지역 엔티티로 변경하기
 
 	@Column(unique = true)
-	private String kakaoUuid;
+	private String phone;
 	private boolean acceptMessage;
 
 	@Enumerated(EnumType.STRING)
@@ -73,6 +73,11 @@ public class Member extends BaseEntity {
 		if (this.userStatus == UserStatus.INACTIVE && this.isActive()) {
 			this.userStatus = UserStatus.ACTIVE;
 		}
+		return this;
+	}
+
+	public Member phoneUpdate(String phone) {
+		this.phone = phone;
 		return this;
 	}
 

--- a/src/main/java/com/seungah/todayclothes/service/MemberService.java
+++ b/src/main/java/com/seungah/todayclothes/service/MemberService.java
@@ -10,6 +10,7 @@ import com.seungah.todayclothes.entity.Member;
 import com.seungah.todayclothes.repository.MemberRepository;
 import com.seungah.todayclothes.util.AuthNumberRedisUtils;
 import com.seungah.todayclothes.util.MailUtils;
+import com.seungah.todayclothes.util.SmsUtils;
 import java.util.Random;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final MailUtils mailUtils;
-//	private final SmsUtils smsUtils;
+	private final SmsUtils smsUtils;
 	private final AuthNumberRedisUtils authNumberRedisUtils;
 
 	
@@ -56,8 +57,7 @@ public class MemberService {
 			.orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
 
 		String authNumber = issueAuthNumber();
-		// TODO
-//		smsService.sendSms(phone, title, content); // title, content
+		smsUtils.sendSms(phone, "핸드폰 인증 번호 [" + authNumber + "]를 입력해 주세요.");
 		authNumberRedisUtils.put(phone, authNumber);
 	}
 

--- a/src/main/java/com/seungah/todayclothes/util/AuthNumberRedisUtils.java
+++ b/src/main/java/com/seungah/todayclothes/util/AuthNumberRedisUtils.java
@@ -1,0 +1,37 @@
+package com.seungah.todayclothes.util;
+
+import static com.seungah.todayclothes.common.exception.ErrorCode.NOT_FOUND_AUTH_NUMBER;
+
+import com.seungah.todayclothes.common.exception.CustomException;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class AuthNumberRedisUtils {
+
+	private static final int VALID_TIME = 5;
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void put(String phone, String authNumber) {
+		ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+		valueOperations.set(phone, authNumber, Duration.ofMinutes(VALID_TIME));
+	}
+
+	public String get(String phone) {
+		ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+		String value = valueOperations.get(phone);
+		if (value == null) {
+			throw new CustomException(NOT_FOUND_AUTH_NUMBER);
+		}
+		return value;
+	}
+
+	public void delete(String phone) {
+		redisTemplate.delete(phone);
+	}
+
+}

--- a/src/main/java/com/seungah/todayclothes/util/SmsUtils.java
+++ b/src/main/java/com/seungah/todayclothes/util/SmsUtils.java
@@ -1,0 +1,112 @@
+package com.seungah.todayclothes.util;
+
+import static com.seungah.todayclothes.common.exception.ErrorCode.FAILED_SEND_SMS;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seungah.todayclothes.common.exception.CustomException;
+import com.seungah.todayclothes.dto.SmsDto;
+import com.seungah.todayclothes.dto.SmsDto.Message;
+import java.net.URI;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+public class SmsUtils {
+
+	@Value("${naver.service-id}")
+	private String serviceId;
+	@Value("${naver.access-key}")
+	private String accessKey;
+	@Value("${naver.secret-key}")
+	private String secretKey;
+	@Value("${naver.phone}")
+	private String phone;
+
+	public void sendSms(String from, String content) {
+		String timestamp = Long.toString(System.currentTimeMillis());
+
+		URI apiUri = UriComponentsBuilder.newInstance()
+			.scheme("https").host("sens.apigw.ntruss.com")
+			.path("/sms/v2/services/{serviceId}/messages")
+			.buildAndExpand(serviceId).toUri();
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.set("x-ncp-apigw-timestamp", timestamp);
+		headers.set("x-ncp-iam-access-key", accessKey);
+		headers.set("x-ncp-apigw-signature-v2", getSignature(timestamp));
+
+		SmsDto smsDto = getSmsDto(from, content);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		String body = null;
+		try {
+			body = objectMapper.writeValueAsString(smsDto);
+		} catch (JsonProcessingException e) {
+			log.info(e.getMessage());
+			throw new CustomException(FAILED_SEND_SMS);
+		}
+		var request = new HttpEntity<>(body, headers);
+
+		RestTemplate restTemplate = new RestTemplate();
+		ResponseEntity<String> response = restTemplate.exchange(
+			apiUri, HttpMethod.POST, request, String.class);
+
+		int responseCode = response.getStatusCodeValue();
+		if (responseCode != 202) {
+			log.info(String.valueOf(responseCode));
+			throw new CustomException(FAILED_SEND_SMS);
+		}
+	}
+
+	private SmsDto getSmsDto(String from, String content) {
+		Message message = Message.from(from, content);
+		List<Message> messages = new ArrayList<>();
+		messages.add(message);
+		return SmsDto.from(from, phone, messages);
+	}
+
+	private String getSignature(String time) {
+		String space = " ";
+		String newLine = "\n";
+		String method = "POST";
+		String url = "/sms/v2/services/" + serviceId + "/messages";
+
+		String message = method + space + url
+			+ newLine + time + newLine + accessKey;
+
+		SecretKeySpec signingKey = new SecretKeySpec(
+			secretKey.getBytes(UTF_8), "HmacSHA256");
+		Mac mac = null;
+		try {
+			mac = Mac.getInstance("HmacSHA256");
+			mac.init(signingKey);
+		} catch (NoSuchAlgorithmException | InvalidKeyException e) {
+			log.info(e.getMessage());
+			throw new CustomException(FAILED_SEND_SMS);
+		}
+
+		byte[] rawHmac = mac.doFinal(message.getBytes(UTF_8));
+
+		return Base64.getEncoder().encodeToString(rawHmac);
+	}
+
+}


### PR DESCRIPTION
## 📕 제목
- #17 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 회원 핸드폰 인증 번호 발급, 발급된 인증 번호 레디스 저장
- [x] 인증 번호 체크 API 구현, 성공 시 인증 번호 레디스 삭제
- [x] SMS 전송 유틸 구현

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Member 테이블에 phone(핸드폰 번호) 추가
- 메시지 한 번에 여러 개 보낼 게 있는지
