### PR TITLE
Feat: 회원 정보(마이페이지) 로직 수정 & 회원 로그아웃 구현

### DIFF
--- a/src/main/java/com/seungah/todayclothes/domain/member/controller/AuthController.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/controller/AuthController.java
@@ -1,17 +1,21 @@
 package com.seungah.todayclothes.domain.member.controller;
 
-import com.seungah.todayclothes.global.jwt.TokenDto;
+import static com.seungah.todayclothes.global.jwt.JwtProvider.ACCESS_TOKEN_COOKIE_NAME;
+
 import com.seungah.todayclothes.domain.member.dto.request.CheckAuthKeyRequest;
 import com.seungah.todayclothes.domain.member.dto.request.SendAuthKeyRequest;
 import com.seungah.todayclothes.domain.member.dto.request.SignInRequest;
 import com.seungah.todayclothes.domain.member.dto.request.SignUpRequest;
 import com.seungah.todayclothes.domain.member.dto.response.CheckAuthKeyResponse;
 import com.seungah.todayclothes.domain.member.service.AuthService;
+import com.seungah.todayclothes.global.jwt.TokenDto;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -53,6 +57,15 @@ public class AuthController {
 
 		response.addHeader(HttpHeaders.SET_COOKIE, dto.getAccessTokenCookie().toString());
 		response.addHeader(HttpHeaders.SET_COOKIE, dto.getRefreshTokenCookie().toString());
+
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/sign-out")
+	public ResponseEntity<Void> signOut(@AuthenticationPrincipal Long userId,
+		@CookieValue(ACCESS_TOKEN_COOKIE_NAME) String accessToken
+	) {
+		authService.signOut(userId, accessToken);
 
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/seungah/todayclothes/domain/member/controller/MemberController.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/controller/MemberController.java
@@ -3,10 +3,9 @@ package com.seungah.todayclothes.domain.member.controller;
 import com.seungah.todayclothes.domain.member.dto.request.CheckAuthNumberRequest;
 import com.seungah.todayclothes.domain.member.dto.request.FindPasswordRequest;
 import com.seungah.todayclothes.domain.member.dto.request.SendAuthNumberRequest;
-import com.seungah.todayclothes.domain.member.dto.request.UpdateGenderRequest;
+import com.seungah.todayclothes.domain.member.dto.request.UpdateMemberInfoRequest;
 import com.seungah.todayclothes.domain.member.dto.request.UpdateNameRequest;
 import com.seungah.todayclothes.domain.member.dto.request.UpdatePasswordRequest;
-import com.seungah.todayclothes.domain.member.dto.request.UpdateRegionRequest;
 import com.seungah.todayclothes.domain.member.dto.response.CheckAuthNumberResponse;
 import com.seungah.todayclothes.domain.member.dto.response.GetProfileResponse;
 import com.seungah.todayclothes.domain.member.service.MemberService;
@@ -34,21 +33,13 @@ public class MemberController {
 		return ResponseEntity.ok(memberService.getProfile(userId));
 	}
 
-	@PutMapping("/gender")
-	public ResponseEntity<GetProfileResponse> updateGender(@Valid @RequestBody UpdateGenderRequest request,
+	@PutMapping("/active-info")
+	public ResponseEntity<?> updateActiveMemberInfo(
+		@Valid @RequestBody UpdateMemberInfoRequest request,
 		@AuthenticationPrincipal Long userId) {
-
 		return ResponseEntity.ok(
-			memberService.updateGender(userId, request.getGender())
-		);
-	}
-
-	@PutMapping("/region")
-	public ResponseEntity<GetProfileResponse> updateRegion(@Valid @RequestBody UpdateRegionRequest request,
-		@AuthenticationPrincipal Long userId) {
-
-		return ResponseEntity.ok(
-			memberService.updateRegion(userId, request.getRegion())
+			memberService.updateActiveMemberInfo(
+				userId, request.getRegion(), request.getGender())
 		);
 	}
 

--- a/src/main/java/com/seungah/todayclothes/domain/member/dto/request/UpdateMemberInfoRequest.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/dto/request/UpdateMemberInfoRequest.java
@@ -1,0 +1,18 @@
+package com.seungah.todayclothes.domain.member.dto.request;
+
+import com.seungah.todayclothes.global.type.Gender;
+import com.seungah.todayclothes.global.type.valid.EnumTypeValid;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class UpdateMemberInfoRequest {
+
+	@NotNull(message = "지역을 입력해 주세요.")
+	private String region; // TODO
+
+	@EnumTypeValid(enumClass = Gender.class, message = "Invalid Gender")
+	@NotNull(message = "성별(MALE, FEMALE)를 선택하세요.")
+	private String gender;
+
+}

--- a/src/main/java/com/seungah/todayclothes/domain/member/dto/response/GetProfileResponse.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/dto/response/GetProfileResponse.java
@@ -17,7 +17,6 @@ public class GetProfileResponse {
 	private Long memberId;
 	private String email;
 	private String name;
-	//private String password;
 	private Gender gender;
 	private String region;
 	private String phone;

--- a/src/main/java/com/seungah/todayclothes/domain/member/entity/Member.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/entity/Member.java
@@ -1,6 +1,9 @@
 package com.seungah.todayclothes.domain.member.entity;
 
+import static com.seungah.todayclothes.global.exception.ErrorCode.NOT_SEND_BOTH_GENDER_AND_REGION;
+
 import com.seungah.todayclothes.global.common.BaseEntity;
+import com.seungah.todayclothes.global.exception.CustomException;
 import com.seungah.todayclothes.global.type.Gender;
 import com.seungah.todayclothes.global.type.SignUpType;
 import com.seungah.todayclothes.global.type.UserStatus;
@@ -43,7 +46,6 @@ public class Member extends BaseEntity {
 
 	@Column(unique = true)
 	private String phone;
-	private boolean acceptMessage;
 
 	@Enumerated(EnumType.STRING)
 	private SignUpType signUpType;
@@ -60,29 +62,14 @@ public class Member extends BaseEntity {
 		return this;
 	}
 
-	public Member genderUpdate(String gender) {
+	public void activeMemberInfoUpdate(String region, String gender) {
+		if (gender == null || region == null) {
+			throw new CustomException(NOT_SEND_BOTH_GENDER_AND_REGION);
+		}
+
 		this.gender = Gender.valueOf(gender);
-		if (this.userStatus == UserStatus.INACTIVE && this.isActive()) {
-			this.userStatus = UserStatus.ACTIVE;
-		}
-		return this;
-	}
-
-	public Member regionUpdate(String region) {
 		this.region = region;
-		if (this.userStatus == UserStatus.INACTIVE && this.isActive()) {
-			this.userStatus = UserStatus.ACTIVE;
-		}
-		return this;
-	}
-
-	public Member phoneUpdate(String phone) {
-		this.phone = phone;
-		return this;
-	}
-
-	public boolean isActive() {
-		return this.gender != null && this.region != null;
+		this.userStatus = UserStatus.ACTIVE;
 	}
 
 }

--- a/src/main/java/com/seungah/todayclothes/domain/member/service/AuthService.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/service/AuthService.java
@@ -9,6 +9,7 @@ import com.seungah.todayclothes.global.jwt.TokenDto;
 import com.seungah.todayclothes.domain.member.dto.response.CheckAuthKeyResponse;
 import com.seungah.todayclothes.domain.member.entity.Member;
 import com.seungah.todayclothes.domain.member.repository.MemberRepository;
+import com.seungah.todayclothes.global.redis.util.TokenRedisUtils;
 import com.seungah.todayclothes.global.type.SignUpType;
 import com.seungah.todayclothes.global.type.UserStatus;
 import com.seungah.todayclothes.global.redis.util.AuthKeyRedisUtils;
@@ -30,6 +31,7 @@ public class AuthService {
 	private final MailUtils mailUtils;
 	private final AuthKeyRedisUtils authKeyRedisUtils;
 	private final PasswordEncoder passwordEncoder;
+	private final TokenRedisUtils tokenRedisUtils;
 
 	@Transactional
 	public void register(String email, String password, String name) {
@@ -97,6 +99,11 @@ public class AuthService {
 		}
 
 		return jwtProvider.issueToken(member.getId());
+	}
+
+	@Transactional
+	public void signOut(Long userId, String accessToken) {
+		tokenRedisUtils.delete(userId);
 	}
 
 }

--- a/src/main/java/com/seungah/todayclothes/domain/member/service/MemberService.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/service/MemberService.java
@@ -37,19 +37,12 @@ public class MemberService {
 	}
 
 	@Transactional
-	public GetProfileResponse updateGender(Long userId, String gender) {
-		Member member = memberRepository.findById(userId)
-			.orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
+	public GetProfileResponse updateActiveMemberInfo(Long userId, String region, String gender) {
+		Member member = memberRepository.getReferenceById(userId);
 
-		return GetProfileResponse.of(member.genderUpdate(gender));
-	}
+		member.activeMemberInfoUpdate(region, gender);
 
-	@Transactional
-	public GetProfileResponse updateRegion(Long userId, String region) {
-		Member member = memberRepository.findById(userId)
-			.orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
-
-		return GetProfileResponse.of(member.regionUpdate(region));
+		return GetProfileResponse.of(member);
 	}
 
 	public void sendAuthNumberBySms(Long userId, String phone) {
@@ -72,7 +65,7 @@ public class MemberService {
 			return new CheckAuthNumberResponse(false);
 		}
 		authNumberRedisUtils.delete(phone);
-		member.phoneUpdate(phone);
+		member.setPhone(phone);
 		return new CheckAuthNumberResponse(true);
 	}
 

--- a/src/main/java/com/seungah/todayclothes/global/exception/ErrorCode.java
+++ b/src/main/java/com/seungah/todayclothes/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 	INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
 	NOT_MATCH_SIGNUP_TYPE(HttpStatus.BAD_REQUEST, "NOT_MATCH_SIGNUP_TYPE", "vendor에 일치하는 회원가입 유형이 없습니다."),
 	INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "INVALID_IMAGE_EXTENSION", "처리할 수 없는 이미지 형식입니다."),
+	NOT_SEND_BOTH_GENDER_AND_REGION(HttpStatus.BAD_REQUEST, "NOT_SEND_BOTH_GENDER_AND_REGION", "성별, 지역 정보가 모두 필요합니다."),
 
 	/* 401 */
 	INVALID_AUTH(HttpStatus.UNAUTHORIZED, "INVALID_AUTH", "유효한 인증 정보가 아닙니다."),

--- a/src/main/java/com/seungah/todayclothes/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/seungah/todayclothes/global/jwt/JwtAuthenticationEntryPoint.java
@@ -35,7 +35,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 	private void setResponse(HttpServletResponse response, ErrorCode errorCode)
 		throws IOException {
 		response.setContentType("application/json;charset=UTF-8");
-		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setStatus(errorCode.getHttpStatus().value());
 
 		JSONObject responseObject = new JSONObject();
 		responseObject.put("errorCode", errorCode.getCode());

--- a/src/main/java/com/seungah/todayclothes/global/redis/util/AuthKeyRedisUtils.java
+++ b/src/main/java/com/seungah/todayclothes/global/redis/util/AuthKeyRedisUtils.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class AuthKeyRedisUtils {
 
-	private static final int VALID_TIME = 10;
+	private static final int VALID_TIME = 5;
 	private final RedisTemplate<String, String> redisTemplate;
 
 	public void put(String email, String authKey) {

--- a/src/main/java/com/seungah/todayclothes/global/redis/util/TokenRedisUtils.java
+++ b/src/main/java/com/seungah/todayclothes/global/redis/util/TokenRedisUtils.java
@@ -25,4 +25,8 @@ public class TokenRedisUtils {
 		}
 	}
 
+	public void delete(Long userId) {
+		redisTemplate.delete(String.valueOf(userId));
+	}
+
 }


### PR DESCRIPTION
## 📕 제목
- #29 
- #31

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 회원 성별 수정 API, 회원 지역 수정 API -> ACTIVE 회원 정보 수정 API로 통합
- [x] JWT 인증 실패 response, ErrorCode에 맞는 HttpStatus value로 변경
- [x] 로그아웃 구현
- [x] 이메일 인증 번호 유효기간 10->5분으로 수정

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- member 엔티티에 region 다 같이 수정하기 제발제발제발 잊지마
- logout 브랜치 따로 파는 거 까먹고 같이 올려요.. ㅜㅜ죄송합다
