### PR TITLE
Fix: 일정 별 옷 조회 -> 입력한 지역명 누락 (#48)

### DIFF
--- a/src/main/java/com/seungah/todayclothes/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/seungah/todayclothes/domain/schedule/service/ScheduleService.java
@@ -70,8 +70,8 @@ public class ScheduleService {
 
         // call ai service
         // - plan과 region을 받아 오기 위한 모델 요청
-        String regionName = "";
-        if (request.getRegionName() == null) { // region이 없을 시,
+        String regionName = request.getRegionName();
+        if (regionName == null) { // region이 없을 시,
             regionName = member.getRegion().getName();
         }
         AiScheduleDto aiScheduleDto =


### PR DESCRIPTION
## 📕 제목
- #48

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 일정 별 의류 조회 시, 회원이 입력한 지역명을 고려하지 않고, ai 서버로 요청을 보냄. 결과로, '건대'를 입력하면 '광진구'가 나와야 함에도 불구하고, '대구광역시' default 지역명이 응답으로 와서 아래와 같이 변경

1. 원래 코드 - 회원이 입력한 지역명을 고려하지 않음
```
String regionName = "";
if (request.getRegionName() == null) { // region이 없을 시,
    regionName = member.getRegion().getName();
}
```
2. 바꾼 코드 - 회원이 입력한 지역명을 고려함
```
String regionName = request.getRegionName();
if (regionName == null) { // region이 없을 시,
    regionName = member.getRegion().getName();
}
```

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이사항1
