### PR TITLE
Feat: 의류 선택 좋아요 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {  // querydsl
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.9'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.seungah'
@@ -35,6 +42,10 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'org.seleniumhq.selenium:selenium-java:4.1.2'
 
+    // querydsl
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -45,4 +56,23 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// qeurydsl
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/controller/ClothesChoiceController.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/controller/ClothesChoiceController.java
@@ -32,10 +32,16 @@ public class ClothesChoiceController {
 		return ResponseEntity.ok().build();
 	}
 
-	@GetMapping
-	public ResponseEntity<List<ClothesChoiceResponse>> getClothesChoiceList(@AuthenticationPrincipal Long userId) {
+	@GetMapping("/mine")
+	public ResponseEntity<List<ClothesChoiceResponse>> getUserClothesChoiceList(@AuthenticationPrincipal Long userId) {
 
-		return ResponseEntity.ok(clothesChoiceService.getClothesChoiceList(userId));
+		return ResponseEntity.ok(clothesChoiceService.getUserClothesChoiceList(userId));
+	}
+
+	@GetMapping("/others")
+	public ResponseEntity<List<ClothesChoiceResponse>> getOtherUserClothesChoiceList(@AuthenticationPrincipal Long userId) {
+
+		return ResponseEntity.ok(clothesChoiceService.getOtherUserClothesChoiceList(userId));
 	}
 
 	@DeleteMapping("/{id}")

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/controller/ClothesChoiceController.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/controller/ClothesChoiceController.java
@@ -3,9 +3,10 @@ package com.seungah.todayclothes.domain.clothes.controller;
 import com.seungah.todayclothes.domain.clothes.dto.request.ChoiceClothesRequest;
 import com.seungah.todayclothes.domain.clothes.dto.response.ClothesChoiceResponse;
 import com.seungah.todayclothes.domain.clothes.service.ClothesChoiceService;
-import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -33,15 +35,25 @@ public class ClothesChoiceController {
 	}
 
 	@GetMapping("/mine")
-	public ResponseEntity<List<ClothesChoiceResponse>> getUserClothesChoiceList(@AuthenticationPrincipal Long userId) {
-
-		return ResponseEntity.ok(clothesChoiceService.getUserClothesChoiceList(userId));
+	public ResponseEntity<Slice<ClothesChoiceResponse>> getUserClothesChoiceList(
+		@RequestParam(required = false) Long lastClothesChoiceId,
+		@AuthenticationPrincipal Long userId, Pageable pageable
+	) {
+		return ResponseEntity.ok(
+			clothesChoiceService.getUserClothesChoiceList(
+				userId, lastClothesChoiceId, pageable)
+		);
 	}
 
 	@GetMapping("/others")
-	public ResponseEntity<List<ClothesChoiceResponse>> getOtherUserClothesChoiceList(@AuthenticationPrincipal Long userId) {
+	public ResponseEntity<Slice<ClothesChoiceResponse>> getOtherUserClothesChoiceList(
+		@RequestParam(required = false) Long lastClothesChoiceId,
+		@AuthenticationPrincipal Long userId, Pageable pageable) {
 
-		return ResponseEntity.ok(clothesChoiceService.getOtherUserClothesChoiceList(userId));
+		return ResponseEntity.ok(
+			clothesChoiceService.getOtherUserClothesChoiceList(
+				userId, lastClothesChoiceId, pageable)
+		);
 	}
 
 	@DeleteMapping("/{id}")

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/controller/ClothesChoiceController.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/controller/ClothesChoiceController.java
@@ -48,7 +48,8 @@ public class ClothesChoiceController {
 	@GetMapping("/others")
 	public ResponseEntity<Slice<ClothesChoiceResponse>> getOtherUserClothesChoiceList(
 		@RequestParam(required = false) Long lastClothesChoiceId,
-		@AuthenticationPrincipal Long userId, Pageable pageable) {
+		@AuthenticationPrincipal Long userId, Pageable pageable
+	) {
 
 		return ResponseEntity.ok(
 			clothesChoiceService.getOtherUserClothesChoiceList(

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/dto/response/ClothesChoiceResponse.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/dto/response/ClothesChoiceResponse.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ClothesChoiceResponse {
-
+	private Long id;
 	private Long memberId;
 
 	private LocalDate date;
@@ -26,9 +26,11 @@ public class ClothesChoiceResponse {
 
 	public static ClothesChoiceResponse of(ClothesChoice clothesChoice) {
 		return ClothesChoiceResponse.builder()
+			.id(clothesChoice.getId())
 			.memberId(clothesChoice.getMember().getId())
 			.date(clothesChoice.getScheduleDetail().getSchedule().getDate())
 			.tempAvg(clothesChoice.getScheduleDetail().getAvgTemp())
+			.plan(clothesChoice.getScheduleDetail().getPlan())
 			.topChoice(TopChoiceDto.of(clothesChoice.getTop()))
 			.bottomChoice(BottomChoiceDto.of(clothesChoice.getBottom()))
 			.build();

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/entity/ClothesChoice.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/entity/ClothesChoice.java
@@ -14,8 +14,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.NamedAttributeNode;
-import javax.persistence.NamedEntityGraph;
 import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,14 +25,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@NamedEntityGraph(name = "clothesChoiceWithAssociations",
-	attributeNodes = {
-		@NamedAttributeNode("top"),
-		@NamedAttributeNode("bottom"),
-		@NamedAttributeNode("scheduleDetail"),
-		@NamedAttributeNode("member")
-	}
-)
 public class ClothesChoice extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/entity/ClothesChoice.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/entity/ClothesChoice.java
@@ -1,8 +1,12 @@
 package com.seungah.todayclothes.domain.clothes.entity;
 
+import com.seungah.todayclothes.domain.member.entity.Likes;
 import com.seungah.todayclothes.domain.member.entity.Member;
 import com.seungah.todayclothes.domain.schedule.entity.ScheduleDetail;
 import com.seungah.todayclothes.global.common.BaseEntity;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -12,6 +16,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedAttributeNode;
 import javax.persistence.NamedEntityGraph;
+import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -51,5 +56,9 @@ public class ClothesChoice extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
+
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "likes_id")
+	private List<Likes> likes = new ArrayList<>();
 
 }

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/repository/ClothesChoiceQueryRepository.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/repository/ClothesChoiceQueryRepository.java
@@ -1,0 +1,16 @@
+package com.seungah.todayclothes.domain.clothes.repository;
+
+import com.seungah.todayclothes.domain.clothes.dto.response.ClothesChoiceResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface ClothesChoiceQueryRepository {
+
+	Slice<ClothesChoiceResponse> searchByMember(
+		Long lastClothesChoiceId, Long userId, Pageable pageable
+	);
+
+	Slice<ClothesChoiceResponse> searchExceptForMember(
+		Long lastClothesChoiceId, Long userId, Pageable pageable
+	);
+}

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/repository/ClothesChoiceQueryRepositoryImpl.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/repository/ClothesChoiceQueryRepositoryImpl.java
@@ -1,0 +1,83 @@
+package com.seungah.todayclothes.domain.clothes.repository;
+
+import static com.seungah.todayclothes.domain.clothes.entity.QClothesChoice.clothesChoice;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.seungah.todayclothes.domain.clothes.dto.response.ClothesChoiceResponse;
+import com.seungah.todayclothes.domain.clothes.entity.ClothesChoice;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ClothesChoiceQueryRepositoryImpl implements ClothesChoiceQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Slice<ClothesChoiceResponse> searchByMember(
+		Long lastClothesChoiceId, Long userId, Pageable pageable
+	) {
+		List<ClothesChoice> clothesChoiceList = queryFactory
+			.selectFrom(clothesChoice)
+			.where(
+				ltClothesChoiceId(lastClothesChoiceId),
+				clothesChoice.member.id.eq(userId)
+			)
+			.orderBy(clothesChoice.id.desc())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		List<ClothesChoiceResponse> clothesChoiceResponseList =
+			clothesChoiceList.stream()
+				.map(ClothesChoiceResponse::of)
+				.collect(Collectors.toList());
+		return checkLastPage(pageable, clothesChoiceResponseList);
+	}
+
+	@Override
+	public Slice<ClothesChoiceResponse> searchExceptForMember(
+		Long lastClothesChoiceId, Long userId, Pageable pageable
+	) {
+		List<ClothesChoice> clothesChoiceList = queryFactory
+			.selectFrom(clothesChoice)
+			.where(
+				ltClothesChoiceId(lastClothesChoiceId),
+				clothesChoice.member.id.ne(userId)
+			)
+			.orderBy(clothesChoice.id.desc())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		List<ClothesChoiceResponse> clothesChoiceResponseList =
+			clothesChoiceList.stream()
+				.map(ClothesChoiceResponse::of)
+				.collect(Collectors.toList());
+		return checkLastPage(pageable, clothesChoiceResponseList);
+	}
+
+	private BooleanExpression ltClothesChoiceId(Long clothesChoiceId) {
+		if (clothesChoiceId == null) {
+			return null;
+		}
+
+		return clothesChoice.id.lt(clothesChoiceId);
+	}
+
+	private Slice<ClothesChoiceResponse> checkLastPage(Pageable pageable, List<ClothesChoiceResponse> results) {
+		boolean hasNext = false;
+
+		if (results.size() > pageable.getPageSize()) {
+			hasNext = true;
+			results.remove(pageable.getPageSize());
+		}
+
+		return new SliceImpl<>(results, pageable, hasNext);
+	}
+}

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/repository/ClothesChoiceRepository.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/repository/ClothesChoiceRepository.java
@@ -6,6 +6,8 @@ import com.seungah.todayclothes.domain.schedule.entity.ScheduleDetail;
 import java.util.List;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,7 +16,13 @@ public interface ClothesChoiceRepository extends JpaRepository<ClothesChoice, Lo
 	@EntityGraph(value = "clothesChoiceWithAssociations", type = EntityGraph.EntityGraphType.LOAD)
 	List<ClothesChoice> findAllByMember(Member member);
 
+	@EntityGraph(value = "clothesChoiceWithAssociations", type = EntityGraph.EntityGraphType.LOAD)
+	@Query("SELECT cc FROM ClothesChoice cc WHERE cc.member <> :member")
+	List<ClothesChoice> findAllExceptForMember(@Param("member") Member member);
+
 	void deleteAllByScheduleDetail(ScheduleDetail scheduleDetail);
 
+	@Query("SELECT l.clothesChoice FROM Likes l WHERE l.member = :member")
+	List<ClothesChoice> findLikeClothesChoicesByMember(@Param("member") Member member);
 
 }

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/repository/ClothesChoiceRepository.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/repository/ClothesChoiceRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ClothesChoiceRepository extends JpaRepository<ClothesChoice, Long> {
+public interface ClothesChoiceRepository extends JpaRepository<ClothesChoice, Long>, ClothesChoiceQueryRepository {
 
 	@EntityGraph(value = "clothesChoiceWithAssociations", type = EntityGraph.EntityGraphType.LOAD)
 	List<ClothesChoice> findAllByMember(Member member);

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/repository/ClothesChoiceRepository.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/repository/ClothesChoiceRepository.java
@@ -4,7 +4,6 @@ import com.seungah.todayclothes.domain.clothes.entity.ClothesChoice;
 import com.seungah.todayclothes.domain.member.entity.Member;
 import com.seungah.todayclothes.domain.schedule.entity.ScheduleDetail;
 import java.util.List;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,13 +11,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClothesChoiceRepository extends JpaRepository<ClothesChoice, Long>, ClothesChoiceQueryRepository {
-
-	@EntityGraph(value = "clothesChoiceWithAssociations", type = EntityGraph.EntityGraphType.LOAD)
-	List<ClothesChoice> findAllByMember(Member member);
-
-	@EntityGraph(value = "clothesChoiceWithAssociations", type = EntityGraph.EntityGraphType.LOAD)
-	@Query("SELECT cc FROM ClothesChoice cc WHERE cc.member <> :member")
-	List<ClothesChoice> findAllExceptForMember(@Param("member") Member member);
 
 	void deleteAllByScheduleDetail(ScheduleDetail scheduleDetail);
 

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/service/ClothesChoiceService.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/service/ClothesChoiceService.java
@@ -59,12 +59,30 @@ public class ClothesChoiceService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<ClothesChoiceResponse> getClothesChoiceList(Long userId) {
+	public List<ClothesChoiceResponse> getUserClothesChoiceList(Long userId) {
 		// member
 		Member member = memberRepository.getReferenceById(userId);
 
 		// clothes choice
 		List<ClothesChoice> clothesChoiceList = clothesChoiceRepository.findAllByMember(member);
+
+		// return
+		List<ClothesChoiceResponse> clothesChoiceResponseList = new ArrayList<>();
+		for (ClothesChoice clothesChoice: clothesChoiceList) {
+			clothesChoiceResponseList.add(
+				ClothesChoiceResponse.of(clothesChoice));
+		}
+
+		return clothesChoiceResponseList;
+	}
+
+	@Transactional(readOnly = true)
+	public List<ClothesChoiceResponse> getOtherUserClothesChoiceList(Long userId) {
+		// member
+		Member member = memberRepository.getReferenceById(userId);
+
+		// clothes choice
+		List<ClothesChoice> clothesChoiceList = clothesChoiceRepository.findAllExceptForMember(member);
 
 		// return
 		List<ClothesChoiceResponse> clothesChoiceResponseList = new ArrayList<>();

--- a/src/main/java/com/seungah/todayclothes/domain/clothes/service/ClothesChoiceService.java
+++ b/src/main/java/com/seungah/todayclothes/domain/clothes/service/ClothesChoiceService.java
@@ -18,9 +18,9 @@ import com.seungah.todayclothes.domain.member.repository.MemberRepository;
 import com.seungah.todayclothes.domain.schedule.entity.ScheduleDetail;
 import com.seungah.todayclothes.domain.schedule.repository.ScheduleDetailRepository;
 import com.seungah.todayclothes.global.exception.CustomException;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,39 +59,19 @@ public class ClothesChoiceService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<ClothesChoiceResponse> getUserClothesChoiceList(Long userId) {
-		// member
-		Member member = memberRepository.getReferenceById(userId);
-
-		// clothes choice
-		List<ClothesChoice> clothesChoiceList = clothesChoiceRepository.findAllByMember(member);
-
-		// return
-		List<ClothesChoiceResponse> clothesChoiceResponseList = new ArrayList<>();
-		for (ClothesChoice clothesChoice: clothesChoiceList) {
-			clothesChoiceResponseList.add(
-				ClothesChoiceResponse.of(clothesChoice));
-		}
-
-		return clothesChoiceResponseList;
+	public Slice<ClothesChoiceResponse> getUserClothesChoiceList(
+		Long userId, Long lastClothesChoiceId, Pageable pageable
+	) {
+		return clothesChoiceRepository
+			.searchByMember(lastClothesChoiceId, userId, pageable);
 	}
 
 	@Transactional(readOnly = true)
-	public List<ClothesChoiceResponse> getOtherUserClothesChoiceList(Long userId) {
-		// member
-		Member member = memberRepository.getReferenceById(userId);
+	public Slice<ClothesChoiceResponse> getOtherUserClothesChoiceList(
+		Long userId, Long lastClothesChoiceId, Pageable pageable) {
 
-		// clothes choice
-		List<ClothesChoice> clothesChoiceList = clothesChoiceRepository.findAllExceptForMember(member);
-
-		// return
-		List<ClothesChoiceResponse> clothesChoiceResponseList = new ArrayList<>();
-		for (ClothesChoice clothesChoice: clothesChoiceList) {
-			clothesChoiceResponseList.add(
-				ClothesChoiceResponse.of(clothesChoice));
-		}
-
-		return clothesChoiceResponseList;
+		return clothesChoiceRepository
+			.searchExceptForMember(lastClothesChoiceId, userId, pageable);
 	}
 
 	@Transactional

--- a/src/main/java/com/seungah/todayclothes/domain/member/controller/LikesController.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/controller/LikesController.java
@@ -1,0 +1,52 @@
+package com.seungah.todayclothes.domain.member.controller;
+
+import com.seungah.todayclothes.domain.clothes.dto.response.ClothesChoiceResponse;
+import com.seungah.todayclothes.domain.member.service.LikesService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/clothes/choice")
+public class LikesController {
+
+	private final LikesService likesService;
+
+	@PostMapping("/{id}/like")
+	public ResponseEntity<Void> createLike(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable(name = "id") Long clothesChoiceId
+	){
+		likesService.pressLikeOnClothesChoice(userId, clothesChoiceId);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/like")
+	public ResponseEntity<List<ClothesChoiceResponse>> getUserLikeList(
+		@AuthenticationPrincipal Long userId // TODO page or slice
+	){
+		return ResponseEntity.ok(
+			likesService.getUserLikeList(userId)
+		);
+	}
+
+	@DeleteMapping("/like/{id}")
+	public ResponseEntity<Void> deleteLike(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable(name = "id") Long clothesChoiceId
+	){
+		likesService.cancelLikeOnClothesChoice(userId, clothesChoiceId);
+
+		return ResponseEntity.ok().build();
+	}
+
+}

--- a/src/main/java/com/seungah/todayclothes/domain/member/controller/LikesController.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/controller/LikesController.java
@@ -1,9 +1,10 @@
 package com.seungah.todayclothes.domain.member.controller;
 
-import com.seungah.todayclothes.domain.clothes.dto.response.ClothesChoiceResponse;
+import com.seungah.todayclothes.domain.member.dto.response.LikesResponse;
 import com.seungah.todayclothes.domain.member.service.LikesService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -31,11 +33,13 @@ public class LikesController {
 	}
 
 	@GetMapping("/like")
-	public ResponseEntity<List<ClothesChoiceResponse>> getUserLikeList(
-		@AuthenticationPrincipal Long userId // TODO page or slice
-	){
+	public ResponseEntity<Slice<LikesResponse>> getUserLikeList(
+		@RequestParam(required = false) Long lastLikesId,
+		@AuthenticationPrincipal Long userId, Pageable pageable
+	) {
+
 		return ResponseEntity.ok(
-			likesService.getUserLikeList(userId)
+			likesService.getUserLikeList(userId, lastLikesId, pageable)
 		);
 	}
 

--- a/src/main/java/com/seungah/todayclothes/domain/member/dto/response/GetProfileResponse.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/dto/response/GetProfileResponse.java
@@ -1,6 +1,7 @@
 package com.seungah.todayclothes.domain.member.dto.response;
 
 import com.seungah.todayclothes.domain.member.entity.Member;
+import com.seungah.todayclothes.domain.region.entity.Region;
 import com.seungah.todayclothes.global.type.Gender;
 import com.seungah.todayclothes.global.type.SignUpType;
 import com.seungah.todayclothes.global.type.UserStatus;
@@ -24,12 +25,13 @@ public class GetProfileResponse {
 	private UserStatus userStatus;
 
 	public static GetProfileResponse of(Member member) {
+		Region region = member.getRegion();
 		return GetProfileResponse.builder()
 			.memberId(member.getId())
 			.name(member.getName())
 			.email(member.getEmail())
 			.gender(member.getGender())
-			.region(member.getRegion().getName()) // TODO
+			.region(region == null ? null : member.getRegion().getName())
 			.phone(member.getPhone())
 			.signUpType(member.getSignUpType())
 			.userStatus(member.getUserStatus())

--- a/src/main/java/com/seungah/todayclothes/domain/member/dto/response/LikesResponse.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/dto/response/LikesResponse.java
@@ -1,0 +1,26 @@
+package com.seungah.todayclothes.domain.member.dto.response;
+
+import com.seungah.todayclothes.domain.clothes.dto.response.ClothesChoiceResponse;
+import com.seungah.todayclothes.domain.member.entity.Likes;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LikesResponse {
+
+	private Long id;
+	private ClothesChoiceResponse clothes;
+
+	public static LikesResponse of(Likes likes) {
+		return LikesResponse.builder()
+			.id(likes.getId())
+			.clothes(ClothesChoiceResponse.of(likes.getClothesChoice()))
+			.build();
+	}
+
+}

--- a/src/main/java/com/seungah/todayclothes/domain/member/entity/Likes.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/entity/Likes.java
@@ -1,0 +1,42 @@
+package com.seungah.todayclothes.domain.member.entity;
+
+import com.seungah.todayclothes.domain.clothes.entity.ClothesChoice;
+import com.seungah.todayclothes.global.common.BaseEntity;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(uniqueConstraints =
+	@UniqueConstraint(columnNames = {"member_id", "clothes_choice_id"})
+)
+public class Likes extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "clothes_choice_id")
+	private ClothesChoice clothesChoice;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+}

--- a/src/main/java/com/seungah/todayclothes/domain/member/repository/LikesQueryRepository.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/repository/LikesQueryRepository.java
@@ -1,0 +1,13 @@
+package com.seungah.todayclothes.domain.member.repository;
+
+import com.seungah.todayclothes.domain.member.dto.response.LikesResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface LikesQueryRepository {
+
+	Slice<LikesResponse> searchByMember(
+		Long userId, Long lastLikesId, Pageable pageable
+	);
+
+}

--- a/src/main/java/com/seungah/todayclothes/domain/member/repository/LikesQueryRepositoryImpl.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/repository/LikesQueryRepositoryImpl.java
@@ -1,0 +1,61 @@
+package com.seungah.todayclothes.domain.member.repository;
+
+
+import static com.seungah.todayclothes.domain.member.entity.QLikes.likes;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.seungah.todayclothes.domain.member.dto.response.LikesResponse;
+import com.seungah.todayclothes.domain.member.entity.Likes;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LikesQueryRepositoryImpl implements LikesQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Slice<LikesResponse> searchByMember(
+		Long userId, Long lastLikesId, Pageable pageable
+	) {
+		List<Likes> likesList = queryFactory
+			.selectFrom(likes)
+			.where(
+				ltLikesId(lastLikesId),
+				likes.member.id.eq(userId)
+			)
+			.orderBy(likes.id.desc())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		List<LikesResponse> likesResponseList = likesList.stream()
+			.map(LikesResponse::of).collect(Collectors.toList());
+		return checkLastPage(pageable, likesResponseList);
+	}
+
+	private BooleanExpression ltLikesId(Long likesId) {
+		if (likesId == null) {
+			return null;
+		}
+
+		return likes.id.lt(likesId);
+	}
+
+	private Slice<LikesResponse> checkLastPage(Pageable pageable, List<LikesResponse> results) {
+		boolean hasNext = false;
+
+		if (results.size() > pageable.getPageSize()) {
+			hasNext = true;
+			results.remove(pageable.getPageSize());
+		}
+
+		return new SliceImpl<>(results, pageable, hasNext);
+	}
+}

--- a/src/main/java/com/seungah/todayclothes/domain/member/repository/LikesRepository.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/repository/LikesRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface LikesRepository extends JpaRepository<Likes, Long> {
+public interface LikesRepository extends JpaRepository<Likes, Long>, LikesQueryRepository {
 
 	boolean existsByClothesChoiceAndMember(ClothesChoice clothesChoice, Member member);
 

--- a/src/main/java/com/seungah/todayclothes/domain/member/repository/LikesRepository.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/repository/LikesRepository.java
@@ -1,0 +1,15 @@
+package com.seungah.todayclothes.domain.member.repository;
+
+import com.seungah.todayclothes.domain.clothes.entity.ClothesChoice;
+import com.seungah.todayclothes.domain.member.entity.Likes;
+import com.seungah.todayclothes.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikesRepository extends JpaRepository<Likes, Long> {
+
+	boolean existsByClothesChoiceAndMember(ClothesChoice clothesChoice, Member member);
+
+	void deleteByClothesChoiceIdAndMemberId(Long clothesChoiceId, Long userId);
+}

--- a/src/main/java/com/seungah/todayclothes/domain/member/service/LikesService.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/service/LikesService.java
@@ -1,18 +1,18 @@
 package com.seungah.todayclothes.domain.member.service;
 
-import static com.seungah.todayclothes.global.exception.ErrorCode.*;
+import static com.seungah.todayclothes.global.exception.ErrorCode.NOT_FOUND_CLOTHES_CHOICE;
 
-import com.seungah.todayclothes.domain.clothes.dto.response.ClothesChoiceResponse;
 import com.seungah.todayclothes.domain.clothes.entity.ClothesChoice;
 import com.seungah.todayclothes.domain.clothes.repository.ClothesChoiceRepository;
+import com.seungah.todayclothes.domain.member.dto.response.LikesResponse;
 import com.seungah.todayclothes.domain.member.entity.Likes;
 import com.seungah.todayclothes.domain.member.entity.Member;
 import com.seungah.todayclothes.domain.member.repository.LikesRepository;
 import com.seungah.todayclothes.domain.member.repository.MemberRepository;
 import com.seungah.todayclothes.global.exception.CustomException;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,14 +42,11 @@ public class LikesService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<ClothesChoiceResponse> getUserLikeList(Long userId) {
-		Member member = memberRepository.getReferenceById(userId);
+	public Slice<LikesResponse> getUserLikeList(
+		Long userId, Long lastLikesId, Pageable pageable
+	) {
 
-		List<ClothesChoice> clothesChoiceList =
-			clothesChoiceRepository.findLikeClothesChoicesByMember(member);
-
-		return clothesChoiceList.stream().map(ClothesChoiceResponse::of)
-			.collect(Collectors.toList());
+		return likesRepository.searchByMember(userId, lastLikesId, pageable);
 	}
 
 	@Transactional

--- a/src/main/java/com/seungah/todayclothes/domain/member/service/LikesService.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/service/LikesService.java
@@ -31,12 +31,13 @@ public class LikesService {
 			.orElseThrow(() -> new CustomException(NOT_FOUND_CLOTHES_CHOICE));
 
 		if (!likesRepository.existsByClothesChoiceAndMember(clothesChoice, member)) {
-			likesRepository.save(
+			Likes like = likesRepository.save(
 				Likes.builder()
 					.clothesChoice(clothesChoice)
 					.member(member)
 					.build()
 			);
+			clothesChoice.getLikes().add(like);
 		}
 	}
 

--- a/src/main/java/com/seungah/todayclothes/domain/member/service/LikesService.java
+++ b/src/main/java/com/seungah/todayclothes/domain/member/service/LikesService.java
@@ -1,0 +1,60 @@
+package com.seungah.todayclothes.domain.member.service;
+
+import static com.seungah.todayclothes.global.exception.ErrorCode.*;
+
+import com.seungah.todayclothes.domain.clothes.dto.response.ClothesChoiceResponse;
+import com.seungah.todayclothes.domain.clothes.entity.ClothesChoice;
+import com.seungah.todayclothes.domain.clothes.repository.ClothesChoiceRepository;
+import com.seungah.todayclothes.domain.member.entity.Likes;
+import com.seungah.todayclothes.domain.member.entity.Member;
+import com.seungah.todayclothes.domain.member.repository.LikesRepository;
+import com.seungah.todayclothes.domain.member.repository.MemberRepository;
+import com.seungah.todayclothes.global.exception.CustomException;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class LikesService {
+	private final MemberRepository memberRepository;
+	private final LikesRepository likesRepository;
+	private final ClothesChoiceRepository clothesChoiceRepository;
+
+	@Transactional
+	public void pressLikeOnClothesChoice(Long userId, Long clothesChoiceId) {
+		Member member = memberRepository.getReferenceById(userId);
+
+		ClothesChoice clothesChoice = clothesChoiceRepository.findById(clothesChoiceId)
+			.orElseThrow(() -> new CustomException(NOT_FOUND_CLOTHES_CHOICE));
+
+		if (!likesRepository.existsByClothesChoiceAndMember(clothesChoice, member)) {
+			likesRepository.save(
+				Likes.builder()
+					.clothesChoice(clothesChoice)
+					.member(member)
+					.build()
+			);
+		}
+	}
+
+	@Transactional(readOnly = true)
+	public List<ClothesChoiceResponse> getUserLikeList(Long userId) {
+		Member member = memberRepository.getReferenceById(userId);
+
+		List<ClothesChoice> clothesChoiceList =
+			clothesChoiceRepository.findLikeClothesChoicesByMember(member);
+
+		return clothesChoiceList.stream().map(ClothesChoiceResponse::of)
+			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public void cancelLikeOnClothesChoice(Long userId, Long clothesChoiceId) {
+
+		likesRepository.deleteByClothesChoiceIdAndMemberId(clothesChoiceId, userId);
+
+	}
+}

--- a/src/main/java/com/seungah/todayclothes/domain/schedule/entity/ScheduleDetail.java
+++ b/src/main/java/com/seungah/todayclothes/domain/schedule/entity/ScheduleDetail.java
@@ -1,8 +1,8 @@
 package com.seungah.todayclothes.domain.schedule.entity;
 
 import com.seungah.todayclothes.domain.region.entity.Region;
-import com.seungah.todayclothes.global.ai.dto.AiClothesDto;
 import com.seungah.todayclothes.domain.schedule.dto.request.AddScheduleRequest;
+import com.seungah.todayclothes.global.ai.dto.AiClothesDto;
 import com.seungah.todayclothes.global.common.BaseEntity;
 import com.seungah.todayclothes.global.type.TimeOfDay;
 import javax.persistence.Column;

--- a/src/main/java/com/seungah/todayclothes/global/jwt/TokenExpirationConfig.java
+++ b/src/main/java/com/seungah/todayclothes/global/jwt/TokenExpirationConfig.java
@@ -1,7 +1,9 @@
 package com.seungah.todayclothes.global.jwt;
 
 public class TokenExpirationConfig {
-	private static final long ACCESS_TOKEN_EXPIRATION_TIME = 30 * 60 * 1000L; // 30분
+
+	// TODO 30 * 60 * 1000L; // 30분
+	private static final long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L; // 하루
 	private static final long REFRESH_TOKEN_EXPIRATION_TIME = 14 * 24 * 60 * 60 * 1000L; // 2주
 
 	public static long getAccessTokenExpirationTime() {

--- a/src/main/java/com/seungah/todayclothes/global/queryDsl/QueryDslConfig.java
+++ b/src/main/java/com/seungah/todayclothes/global/queryDsl/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.seungah.todayclothes.global.queryDsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(){
+		return new JPAQueryFactory(entityManager);
+	}
+}


### PR DESCRIPTION
## 📕 제목
- #50 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x]  본인 고른 의류, 남이 고른 의류 uri 구분해서 무한스크롤 조회
- [x] 좋아요, 좋아요 삭제, 무한 스크롤 조회

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- GET api/members/profile null 이슈 해결
- clotheschoice-like 연쇄 삭제를 위해 일대다 & Cascade 설정
- 개발 시 편리함을 위해 accessToken 만료시간 24시간으로 변경
- queryDSL gradle에 추가